### PR TITLE
STM32 flashing now exits bootloader

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -123,7 +123,7 @@
 }
 
 - (void)flashSTM32WithFile:(NSString *)file {
-    [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000", @"-D", file]];
+    [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000:leave", @"-D", file]];
 }
 
 - (void)flashKiibohdWithFile:(NSString *)file {

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -232,7 +232,7 @@ namespace QMK_Toolbox
 
         private void ResetHalfkay(string mcu) => RunProcess("teensy_loader_cli.exe", $"-mmcu={mcu} -bv");
 
-        private void FlashStm32(string mcu, string file) => RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000 -D \"{file}\"");
+        private void FlashStm32(string mcu, string file) => RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000:leave -D \"{file}\"");
 
         private void FlashKiibohd(string file) => RunProcess("dfu-util.exe", $"-D \"{file}\"");
 


### PR DESCRIPTION
- dfu-util requires "leave" after the starting address in order to exit the bootloader after the flashing has finished

- Please compile this real quick as I am unable to. Probably missing some dipendencies (or I am just lazy:))