### PR TITLE
Check for .bin extension before attempting flash with dfu-util

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -123,11 +123,19 @@
 }
 
 - (void)flashSTM32WithFile:(NSString *)file {
-    [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000:leave", @"-D", file]];
+    if([file hasSuffix:@".bin"]) {
+        [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000:leave", @"-D", file]];
+    } else {
+        [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
+    }
 }
 
 - (void)flashKiibohdWithFile:(NSString *)file {
-    [self runProcess:@"dfu-util" withArgs:@[@"-D", file]];
+    if([file hasSuffix:@".bin"]) {
+        [self runProcess:@"dfu-util" withArgs:@[@"-D", file]];
+    } else {
+        [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
+    }
 }
 
 - (void)flashAVRISP:(NSString *)mcu withFile:(NSString *)file {

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -131,7 +131,7 @@
 }
 
 - (void)flashKiibohdWithFile:(NSString *)file {
-	if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
+    if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-D", file]];
     } else {
         [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -123,7 +123,7 @@
 }
 
 - (void)flashSTM32WithFile:(NSString *)file {
-    if([file hasSuffix:@".bin"]) {
+    if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000:leave", @"-D", file]];
     } else {
         [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
@@ -131,7 +131,7 @@
 }
 
 - (void)flashKiibohdWithFile:(NSString *)file {
-    if([file hasSuffix:@".bin"]) {
+	if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-D", file]];
     } else {
         [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -241,7 +241,7 @@ namespace QMK_Toolbox
 
         private void FlashStm32(string mcu, string file)
         {
-            if (file.EndsWith(".bin")) {
+            if (Path.GetExtension(file).ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000:leave -D \"{file}\"");
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
@@ -250,7 +250,7 @@ namespace QMK_Toolbox
 
         private void FlashKiibohd(string file)
         {
-            if (file.EndsWith(".bin")) {
+            if (Path.GetExtension(file).ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-D \"{file}\"");
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -241,7 +241,7 @@ namespace QMK_Toolbox
 
         private void FlashStm32(string mcu, string file)
         {
-            if (Path.GetExtension(file).ToLower() == ".bin") {
+            if (Path.GetExtension(file)?.ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000:leave -D \"{file}\"");
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
@@ -250,7 +250,7 @@ namespace QMK_Toolbox
 
         private void FlashKiibohd(string file)
         {
-            if (Path.GetExtension(file).ToLower() == ".bin") {
+            if (Path.GetExtension(file)?.ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-D \"{file}\"");
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -239,9 +239,23 @@ namespace QMK_Toolbox
 
         private void ResetHalfkay(string mcu) => RunProcess("teensy_loader_cli.exe", $"-mmcu={mcu} -bv");
 
-        private void FlashStm32(string mcu, string file) => RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000:leave -D \"{file}\"");
+        private void FlashStm32(string mcu, string file)
+        {
+            if (file.EndsWith(".bin")) {
+                RunProcess("dfu-util.exe", $"-a 0 -d 0483:df11 -s 0x08000000:leave -D \"{file}\"");
+            } else {
+                _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
+            }
+        }
 
-        private void FlashKiibohd(string file) => RunProcess("dfu-util.exe", $"-D \"{file}\"");
+        private void FlashKiibohd(string file)
+        {
+            if (file.EndsWith(".bin")) {
+                RunProcess("dfu-util.exe", $"-D \"{file}\"");
+            } else {
+                _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
+            }
+        }
 
         private void FlashAvrisp(string mcu, string file)
         {


### PR DESCRIPTION
Related issue(s) (if any):
Fixes #63.

Changes:
Added a check to see if the filename ends with ".bin" before trying to use dfu-util.
I can't test this as I don't have an STM32 keyboard, but the logic is pretty simple and I'm reasonably confident it does the right thing. Testers appreciated, of course.