### PR TITLE
[macOS] Allow firmware files to be opened directly

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -109,7 +109,7 @@
     if ([[[filename pathExtension] lowercaseString] isEqualToString:@"qmk"] ||
     [[[filename pathExtension] lowercaseString] isEqualToString:@"hex"] ||
     [[[filename pathExtension] lowercaseString] isEqualToString:@"bin"]) {
-        [self setFilePath:[NSURL URLWithString:filename]];
+        [self setFilePath:[NSURL fileURLWithPath:filename]];
         return true;
     } else {
         return false;

--- a/osx/qmk_toolbox/Info.plist
+++ b/osx/qmk_toolbox/Info.plist
@@ -47,7 +47,7 @@
 			<string>Viewer</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>fm.qmk.bin</string>
+				<string>com.apple.macbinary-archive</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
@@ -121,8 +121,8 @@
 				<string>public.data</string>
 				<string>public.archive</string>
 			</array>
-			<key>UTTypeReferenceURL</key>
-			<string>http://qmk.fm/qmk_file_type</string>
+			<key>UTTypeIdentifier</key>
+			<string>fm.qmk.qmk</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -131,22 +131,19 @@
 				</array>
 			</dict>
 		</dict>
-	</array>
-	<key>UTImportedTypeDeclarations</key>
-	<array>
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
 				<string>public.archive</string>
 			</array>
-			<key>UTTypeReferenceURL</key>
-			<string>http://qmk.fm/qmk_file_type</string>
+			<key>UTTypeIdentifier</key>
+			<string>fm.qmk.hex</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>qmk</string>
+					<string>hex</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Fixes #31.

When opening .hex, .bin or .qmk files from outside of the Toolbox, `setFilePath` wants a filename prepended with either `file://` or `qmk:`, which `URLWithString` doesn't provide, so we should use `fileURLWithPath` here. Now the file path text box populates 👍

By default .bin has a UTI of [`com.apple.macbinary-archive`](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) and opens with Archive Utility, so instead of creating a new UTI we have to use that one.
![openwith](https://user-images.githubusercontent.com/4781841/55210214-71a91d00-523a-11e9-925f-17c2e79576c8.png)
