### PR TITLE
Move PR/issue templates under .github/ and flesh them out a bit more

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank issue
+about: If you're 100% sure that you don't need one of the other issue templates, use this one instead.
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve the QMK Toolbox.
+
+---
+<!-- Provide a general summary of the bug in the title above. -->
+
+<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
+
+## Describe the Bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## System Information
+
+ - Operating system: 
+ - QMK Toolbox version: 
+
+## Additional Context
+
+<!-- Add any other relevant information about the problem here, such as the log output from the Toolbox or an error dialog. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or changes to existing features.
+
+---
+<!--- Provide a general summary of the changes you want in the title above. -->
+
+<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
+
+## Feature Request Type
+
+- [ ] Core functionality
+- [ ] Alteration (enhancement/optimization) of existing feature(s)
+- [ ] New behavior
+
+## Description
+
+<!-- A few sentences describing what it is that you'd like to see in the Toolbox. Additional information (such as links to other related issues or PRs) would be helpful. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--- Provide a general summary of your changes in the title above. -->
+
+<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
+
+## Description
+
+<!--- Describe your changes in detail here. -->
+
+## Types of Changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+- [ ] Core
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Enhancement/optimization
+- [ ] Documentation
+
+## Issues Fixed or Closed by This PR
+
+* 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-OS:
-
-OS Version:
-
-QMK Toolbox version:
-
-Issue description:
-
-QMK Toolbox log:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,0 @@
-Related issue(s) (if any):
-
-Changes:


### PR DESCRIPTION
Making the PR and issue templates for the Toolbox repo look more like the templates for the firmware repo, and tidying them away in `.github/`.