### PR TITLE
Add --force flag to DFU EEPROM reset

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -101,7 +101,7 @@
 - (void)eepromResetDFU:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
-    result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", @"--eeprom", file]];
+    result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", @"--force", @"--eeprom", file]];
 }
 
 - (void)flashCaterina:(NSString *)mcu withFile:(NSString *)file {

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -226,7 +226,7 @@ namespace QMK_Toolbox
 
         private void ResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} reset");
 
-        private void EepromResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} flash --eeprom \"reset.eep\"");
+        private void EepromResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
 
         private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

dfu-programmer will fail to write to EEPROM citing memory not blank, so we need to skip that check.

Reportedly not working with or without `--force` on ATmega32U2 (@drashna).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
