### PR TITLE
Add a button to clear the log output text box

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -266,6 +266,10 @@
     [self setFilePath:[NSURL URLWithString:[NSString stringWithFormat:@"qmk:http://qmk.fm/compiled/%@_default.hex", keyboard]]];
 }
 
+- (IBAction)clearButtonClick:(id)sender {
+    [[self textView] setString: @""];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication {
     return YES;
 }

--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -170,6 +170,9 @@
                                     <size key="minSize" width="639" height="318"/>
                                     <size key="maxSize" width="641" height="10000000"/>
                                     <color key="insertionPointColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <connections>
+                                        <outlet property="menu" destination="H9m-Y6-elE" id="oIU-k2-DPl"/>
+                                    </connections>
                                 </textView>
                             </subviews>
                         </clipView>
@@ -465,5 +468,16 @@
             </view>
             <point key="canvasLocation" x="349.5" y="454.5"/>
         </window>
+        <menu id="H9m-Y6-elE">
+            <items>
+                <menuItem title="Clear" id="82o-TW-Mbd">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="clearButtonClick:" target="Voe-Tx-rLC" id="6FO-CI-SpB"/>
+                    </connections>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="367" y="140"/>
+        </menu>
     </objects>
 </document>

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace QMK_Toolbox {
+namespace QMK_Toolbox {
     partial class MainWindow {
         /// <summary>
         /// Required designer variable.
@@ -53,6 +53,8 @@
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logTextBox = new System.Windows.Forms.RichTextBox();
+            this.contextMenuStrip2 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
             this.flashWhenReadyCheckbox = new System.Windows.Forms.CheckBox();
             this.statusStrip.SuspendLayout();
@@ -60,6 +62,7 @@
             this.fileGroupBox.SuspendLayout();
             this.enabledFlasherGroupBox.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
+            this.contextMenuStrip2.SuspendLayout();
             this.SuspendLayout();
             // 
             // flashButton
@@ -415,6 +418,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.logTextBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
             this.logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.logTextBox.ContextMenuStrip = this.contextMenuStrip2;
             this.logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", global::QMK_Toolbox.Properties.Settings.Default, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.logTextBox.DetectUrls = false;
             this.logTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -429,6 +433,20 @@
             this.logTextBox.WordWrap = false;
             this.logTextBox.ZoomFactor = global::QMK_Toolbox.Properties.Settings.Default.outputZoom;
             this.logTextBox.TextChanged += new System.EventHandler(this.logTextBox_TextChanged);
+            // 
+            // contextMenuStrip2
+            // 
+            this.contextMenuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.clearToolStripMenuItem});
+            this.contextMenuStrip2.Name = "contextMenuStrip2";
+            this.contextMenuStrip2.Size = new System.Drawing.Size(181, 48);
+            // 
+            // clearToolStripMenuItem
+            // 
+            this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
+            this.clearToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.clearToolStripMenuItem.Text = "Clear";
+            this.clearToolStripMenuItem.Click += new System.EventHandler(this.clearButton_Click);
             // 
             // hidList
             // 
@@ -492,6 +510,7 @@
             this.enabledFlasherGroupBox.ResumeLayout(false);
             this.enabledFlasherGroupBox.PerformLayout();
             this.contextMenuStrip1.ResumeLayout(false);
+            this.contextMenuStrip2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -528,6 +547,8 @@
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ComboBox hidList;
         private System.Windows.Forms.CheckBox flashWhenReadyCheckbox;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
+        private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
     }
 }
 

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -1,4 +1,4 @@
-﻿//  Created by Jack Humbert on 9/1/17.
+//  Created by Jack Humbert on 9/1/17.
 //  Copyright © 2017 Jack Humbert. This code is licensed under MIT license (see LICENSE.md for details).
 
 using QMK_Toolbox.Properties;
@@ -305,7 +305,7 @@ namespace QMK_Toolbox
                         _printer.Print("There are no devices available", MessageType.Error);
                     }
 
-                    // Re-enable flash/reset button after flashing 
+                    // Re-enable flash/reset button after flashing
                     this.Invoke((MethodInvoker)delegate
                     {
                         flashButton.Enabled = true;
@@ -522,7 +522,7 @@ namespace QMK_Toolbox
                 {
                     Directory.CreateDirectory(Path.Combine(Application.LocalUserAppDataPath, "downloads"));
                 }
-                
+
                 try
                 {
                     _printer.Print($"Downloading the file: {url}", MessageType.Info);
@@ -776,6 +776,11 @@ namespace QMK_Toolbox
             _devices[deviceIndex].WriteReport(report, ReportWritten);
             _devices[deviceIndex].CloseDevice();
             _printer.Print("Sending report", MessageType.Hid);
+        }
+
+        private void clearButton_Click(object sender, EventArgs e)
+        {
+            logTextBox.Clear();
         }
 
         private void MainWindow_DragDrop(object sender, DragEventArgs e)

--- a/windows/QMK Toolbox/MainWindow.resx
+++ b/windows/QMK Toolbox/MainWindow.resx
@@ -126,6 +126,9 @@
   <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>257, 17</value>
   </metadata>
+  <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>412, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>47</value>
   </metadata>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Right clicking on the log output text box gives you:
![image](https://user-images.githubusercontent.com/4781841/58381249-43f41080-7ffe-11e9-9faa-832ed320016e.png)
Which will empty it out.

~Windows-only ATM since I have no Xcode to hand. I'll add it to this PR tomorrow.~ Done

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
