### PR TITLE
[macOS] Fix loading file:// paths with spaces

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -124,7 +124,7 @@
 - (void)setFilePath:(NSURL *)path {
     NSString * filename = @"";
     if ([path.scheme isEqualToString:@"file"])
-        filename = [[NSString stringWithString:path.absoluteString] stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+        filename = [[path.absoluteString stringByRemovingPercentEncoding] stringByReplacingOccurrencesOfString:@"file://" withString:@""];
     if ([path.scheme isEqualToString:@"qmk"]) {
         NSURL * url;
         if ([path.absoluteString containsString:@"qmk://"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The first thing the Toolbox does when a firmware file is opened is convert its path to an `NSURL`. This has the side effect of percent encoding it. Reasonable, since it *is* a URL, but we don't want it as it just gets passed directly to the flasher tools.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #87
