### PR TITLE
Ignore bluetooth modem

### DIFF
--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -247,7 +247,6 @@ static kern_return_t MyGetModemPath(io_iterator_t serialPortIterator, char *devi
 {
     io_object_t     modemService;
     kern_return_t   kernResult = KERN_FAILURE;
-    Boolean     modemFound = false;
  
     // Initialize the returned path
     *deviceFilePath = '\0';
@@ -288,7 +287,6 @@ static kern_return_t MyGetModemPath(io_iterator_t serialPortIterator, char *devi
                 if ([testDevice rangeOfString:@"Bluetooth"].location == NSNotFound) {
                     memcpy(deviceFilePath, testDeviceFilePath, FILEPATH_SIZE);
                     printf("BSD path: %s\n", deviceFilePath);
-                    modemFound = true;
                     kernResult = KERN_SUCCESS;
                 } else {
                     printf("BSD path (ignored): %s\n", testDeviceFilePath);

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -258,24 +258,23 @@ static kern_return_t MyGetModemPath(io_iterator_t serialPortIterator, char *devi
     {
         CFTypeRef   deviceFilePathAsCFString;
  
-    // Get the callout device's path (/dev/cu.xxxxx).
-    // The callout device should almost always be
-    // used. You would use the dialin device (/dev/tty.xxxxx) when
-    // monitoring a serial port for
-    // incoming calls, for example, a fax listener.
+        // Get the callout device's path (/dev/cu.xxxxx).
+        // The callout device should almost always be
+        // used. You would use the dialin device (/dev/tty.xxxxx) when
+        // monitoring a serial port for
+        // incoming calls, for example, a fax listener.
  
-    deviceFilePathAsCFString = IORegistryEntryCreateCFProperty(modemService,
-                            CFSTR(kIOCalloutDeviceKey),
-                            kCFAllocatorDefault,
-                            0);
+        deviceFilePathAsCFString = IORegistryEntryCreateCFProperty(modemService,
+                                                                   CFSTR(kIOCalloutDeviceKey),
+                                                                   kCFAllocatorDefault,
+                                                                   0);
         if (deviceFilePathAsCFString)
         {
             Boolean result;
  
-        // Convert the path from a CFString to a NULL-terminated C string
-        // for use with the POSIX open() call.
- 
-        result = CFStringGetCString(deviceFilePathAsCFString,
+            // Convert the path from a CFString to a NULL-terminated C string
+            // for use with the POSIX open() call.
+            result = CFStringGetCString(deviceFilePathAsCFString,
                                         deviceFilePath,
                                         maxPathSize,
                                         kCFStringEncodingASCII);
@@ -292,8 +291,7 @@ static kern_return_t MyGetModemPath(io_iterator_t serialPortIterator, char *devi
         printf("\n");
  
         // Release the io_service_t now that we are done with it.
- 
-    (void) IOObjectRelease(modemService);
+        IOObjectRelease(modemService);
     }
  
     return kernResult;


### PR DESCRIPTION
## Description

`/dev/cu.Bluetooth-Incoming-Port` pops up frequently when trying to connect/detect a stock Pro Micro. Ignore this port during the port scan so that the correct device can be found. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
