### PR TITLE
Allow EEPROM reset with USBAsp flasher

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -81,6 +81,8 @@
         [self eepromResetDFU:mcu];
     if ([USB canFlash:Caterina])
         [self eepromResetCaterina:mcu];
+    if ([USB canFlash:USBAsp])
+        [self eepromResetUSBAsp:mcu];
 }
 
 - (void)flashDFU:(NSString *)mcu withFile:(NSString *)file {
@@ -112,6 +114,12 @@
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
+}
+
+- (void)eepromResetUSBAsp:(NSString *)mcu {
+    NSString * result;
+    NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
+    result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbasp", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
 }
 
 - (void)flashHalfkay:(NSString *)mcu withFile:(NSString *)file {

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -215,6 +215,8 @@ namespace QMK_Toolbox
                 EepromResetDfu(mcu);
             if (Usb.CanFlash(Chipset.Caterina))
                 EepromResetCaterina(mcu);
+            if (Usb.CanFlash(Chipset.Usbasp))
+                EepromResetUsbasp(mcu);
         }
 
         private void FlashDfu(string mcu, string file)
@@ -231,6 +233,8 @@ namespace QMK_Toolbox
         private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");
 
         private void EepromResetCaterina(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
+
+        private void EepromResetUsbasp(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c usbasp -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
 
         private void FlashHalfkay(string mcu, string file) => RunProcess("teensy_loader_cli.exe", $"-mmcu={mcu} \"{file}\" -v");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

According to the [USBAspLoader readme](https://github.com/baerwolf/USBaspLoader), this flasher *does* support resetting the EEPROM (though it seems the functionality may not be compiled in by default?).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
