### PR TITLE
[macOS] Fix VID/PID for HID (dis)connect messages

### DIFF
--- a/osx/qmk_toolbox/HID.m
+++ b/osx/qmk_toolbox/HID.m
@@ -43,12 +43,14 @@ static IOHIDManagerRef _hidManager;
 }
 
 static NSString * formatDevice(NSString * str, IOHIDDeviceRef device) {
-    return [NSString stringWithFormat:@"%@ - %@ %@ -- 0x%X:0x%X",
+    unsigned short vendorId = [(NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) shortValue];
+    unsigned short productId = [(NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey)) shortValue];
+    return [NSString stringWithFormat:@"%@ - %@ %@ -- %04X:%04X",
         IOHIDDeviceGetProperty(device, CFSTR(kIOHIDManufacturerKey)),
         IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey)),
         str,
-        (int)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) / 256,
-        (int)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey)) / 256
+        vendorId,
+        productId
     ];
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Noticed that the VID and PID are not displayed correctly for the blue HID messages.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
