### PR TITLE
[Windows] Don't access UI controls in child thread when flashing

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -275,6 +275,8 @@ namespace QMK_Toolbox
             {
                 flashButton.Enabled = false;
                 resetButton.Enabled = false;
+                var mcu = mcuBox.Text;
+                var filePath = filepathBox.Text;
 
                 // Keep the form responsive during firmware flashing
                 new Thread(() =>
@@ -282,12 +284,12 @@ namespace QMK_Toolbox
                     if (_usb.AreDevicesAvailable())
                     {
                         var error = 0;
-                        if (mcuBox.Text == "")
+                        if (mcu == "")
                         {
                             _printer.Print("Please select a microcontroller", MessageType.Error);
                             error++;
                         }
-                        if (filepathBox.Text == "")
+                        if (filePath == "")
                         {
                             _printer.Print("Please select a file", MessageType.Error);
                             error++;
@@ -295,7 +297,7 @@ namespace QMK_Toolbox
                         if (error == 0)
                         {
                             _printer.Print("Attempting to flash, please don't remove device", MessageType.Bootloader);
-                            _flasher.Flash(mcuBox.Text, filepathBox.Text);
+                            _flasher.Flash(mcu, filePath);
                         }
                     }
                     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Pressing the Flash button, for me, throws the following exception:
![ioe](https://user-images.githubusercontent.com/4781841/64237749-52788f00-cf40-11e9-9748-7eeefcd70941.png)

Evidently, it only happens sometimes, because there are not a ton of complaints about it.

Since all we need is to read the values of the path/MCU boxes, we can just store them in variables first, and look at *those*.
The same thing is not necessary for the reset/EEPROM buttons (at present) because they do not create a separate thread. Keeping the form responsive is less critical for those, they typically don't take that much time compared to erasing and flashing.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* I thought there was at least one report in the issue list, but all I can find are macOS crashes and driver-not-installed related crashes on Windows. 🤷‍♂
