### PR TITLE
MCU box improvements

### DIFF
--- a/common/avrdude.conf
+++ b/common/avrdude.conf
@@ -11671,6 +11671,197 @@ part
   ;
 
 #------------------------------------------------------------
+# ATmega16u4
+#------------------------------------------------------------
+
+part
+    id               = "m16u4";
+    desc             = "ATmega16U4";
+    signature        = 0x1e 0x94 0x88;
+    usbpid           = 0x2ff3;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout   = 200;
+    stabdelay   = 100;
+    cmdexedelay   = 25;
+    synchloops    = 32;
+    bytedelay   = 0;
+    pollindex   = 3;
+    pollvalue   = 0x53;
+    predelay    = 1;
+    postdelay   = 1;
+    pollmethod    = 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+  loadpage_lo = "  1   1   0   0      0   0   0   1",
+        "  0   0   0   0      0   0   0   0",
+        "  0   0   0   0      0  a2  a1  a0",
+        "  i   i   i   i      i   i   i   i";
+
+  writepage = "  1   1   0   0      0   0   1   0",
+        "  0   0   x   x      x a10  a9  a8",
+        " a7  a6  a5  a4     a3   0   0   0",
+        "  x   x   x   x      x   x   x   x";
+
+  mode    = 0x41;
+  delay   = 20;
+  blocksize = 4;
+  readsize  = 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          " a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+  mode    = 0x41;
+  delay   = 6;
+  blocksize = 128;
+  readsize  = 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
 # AT90USB646
 #------------------------------------------------------------
 
@@ -14972,6 +15163,34 @@ part
 #------------------
 # Compatibility aliases
 #------------------
+
+part parent "usb1286"
+    id = "at90usb1286";
+;
+
+part parent "usb646"
+    id = "at90usb646";
+;
+
+part parent "m16u2"
+    id = "atmega16u2";
+;
+
+part parent "m16u4"
+    id = "atmega16u4";
+;
+
+part parent "m328p"
+    id = "atmega328p";
+;
+
+part parent "m32"
+    id = "atmega32a";
+;
+
+part parent "m32u2"
+    id = "atmega32u2";
+;
 
 part parent "m32u4"
     id = "atmega32u4";

--- a/common/avrdude.conf
+++ b/common/avrdude.conf
@@ -6081,7 +6081,7 @@ part parent "m649"
 #------------------------------------------------------------
 
 part
-    id               = "m32";
+    id               = "atmega32a";
     desc             = "ATmega32";
     has_jtag         = yes;
     stk500_devcode   = 0x91;
@@ -8676,7 +8676,7 @@ part
 ;
 
 part parent "m328"
-    id			= "m328p";
+    id			= "atmega328p";
     desc		= "ATmega328P";
     signature		= 0x1e 0x95 0x0F;
 
@@ -11484,7 +11484,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m32u4";
+    id               = "atmega32u4";
     desc             = "ATmega32U4";
     signature        = 0x1e 0x95 0x87;
     usbpid           = 0x2ff4;
@@ -11675,7 +11675,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m16u4";
+    id               = "atmega16u4";
     desc             = "ATmega16U4";
     signature        = 0x1e 0x94 0x88;
     usbpid           = 0x2ff3;
@@ -11866,7 +11866,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "usb646";
+    id               = "at90usb646";
     desc             = "AT90USB646";
     signature        = 0x1e 0x96 0x82;
     usbpid           = 0x2ff9;
@@ -12057,8 +12057,8 @@ part
 #------------------------------------------------------------
 # identical to AT90USB646
 
-part parent "usb646"
-    id               = "usb647";
+part parent "at90usb646"
+    id               = "at90usb647";
     desc             = "AT90USB647";
     signature        = 0x1e 0x96 0x82;
 
@@ -12070,7 +12070,7 @@ part parent "usb646"
 #------------------------------------------------------------
 
 part
-    id               = "usb1286";
+    id               = "at90usb1286";
     desc             = "AT90USB1286";
     signature        = 0x1e 0x97 0x82;
     usbpid           = 0x2ffb;
@@ -12261,8 +12261,8 @@ part
 #------------------------------------------------------------
 # identical to AT90USB1286
 
-part parent "usb1286"
-    id               = "usb1287";
+part parent "at90usb1286"
+    id               = "at90usb1287";
     desc             = "AT90USB1287";
     signature        = 0x1e 0x97 0x82;
 
@@ -12650,7 +12650,7 @@ part
 #        size            = 1024;
 #        num_pages       = 256;
 part
-    id               = "m32u2";
+    id               = "atmega32u2";
     desc             = "ATmega32U2";
     has_jtag         = no;
     has_debugwire    = yes;
@@ -12838,7 +12838,7 @@ part
 #        size            = 512;
 #        num_pages       = 128;
 part
-    id               = "m16u2";
+    id               = "atmega16u2";
     desc             = "ATmega16U2";
     has_jtag         = no;
     has_debugwire    = yes;
@@ -15158,40 +15158,4 @@ part
     memory "signature"
         size            = 3;
     ;
-;
-
-#------------------
-# Compatibility aliases
-#------------------
-
-part parent "usb1286"
-    id = "at90usb1286";
-;
-
-part parent "usb646"
-    id = "at90usb646";
-;
-
-part parent "m16u2"
-    id = "atmega16u2";
-;
-
-part parent "m16u4"
-    id = "atmega16u4";
-;
-
-part parent "m328p"
-    id = "atmega328p";
-;
-
-part parent "m32"
-    id = "atmega32a";
-;
-
-part parent "m32u2"
-    id = "atmega32u2";
-;
-
-part parent "m32u4"
-    id = "atmega32u4";
 ;

--- a/common/mcu-list.txt
+++ b/common/mcu-list.txt
@@ -1,5 +1,7 @@
 at90usb1286
+at90usb1287
 at90usb646
+at90usb647
 atmega16u2
 atmega16u4
 atmega328p

--- a/common/mcu-list.txt
+++ b/common/mcu-list.txt
@@ -1,6 +1,8 @@
-atmega32u4
 at90usb1286
-atmega32u2
+at90usb646
 atmega16u2
+atmega16u4
 atmega328p
 atmega32a
+atmega32u2
+atmega32u4

--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -218,13 +218,16 @@
     
     // choose whatever input identity you have decided. in this case ;
     for (NSString * str in allLinedStrings) {
-        [_mcuBox addItemWithObjectValue:str];
+        if ([str length] > 0) {
+            [self.mcuBox addItemWithObjectValue:str];
+        }
     }
-    [_mcuBox selectItemAtIndex:0];
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *lastUsedMCU = [defaults stringForKey:QMKMicrocontrollerKey];
     if (lastUsedMCU) {
         [self.mcuBox selectItemWithObjectValue:lastUsedMCU];
+    } else {
+        [self.mcuBox selectItemWithObjectValue:@"atmega32u4"];
     }
 }
 

--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -258,7 +258,7 @@
                                     <constraints>
                                         <constraint firstAttribute="width" constant="105" id="fYy-tf-ll3"/>
                                     </constraints>
-                                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select MCU" drawsBackground="YES" completes="NO" numberOfVisibleItems="6" id="xEk-tg-smb">
+                                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select MCU" drawsBackground="YES" buttonBordered="NO" completes="NO" numberOfVisibleItems="6" id="xEk-tg-smb">
                                         <font key="font" metaFont="cellTitle"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/windows/QMK Toolbox/App.config
+++ b/windows/QMK Toolbox/App.config
@@ -21,7 +21,7 @@
         <value />
       </setting>
       <setting name="targetSetting" serializeAs="String">
-        <value />
+        <value>atmega32u4</value>
       </setting>
       <setting name="autoSetting" serializeAs="String">
         <value>False</value>

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -295,6 +295,7 @@ namespace QMK_Toolbox {
             // 
             this.mcuBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.mcuBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "targetSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.mcuBox.FormattingEnabled = true;
             this.mcuBox.Location = new System.Drawing.Point(546, 16);
             this.mcuBox.Name = "mcuBox";

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -170,6 +170,7 @@ namespace QMK_Toolbox
         {
             var arraylist = new ArrayList(filepathBox.Items);
             Settings.Default.hexFileCollection = arraylist;
+            Settings.Default.targetSetting = mcuBox.GetItemText(mcuBox.SelectedItem);
             Settings.Default.Save();
         }
 
@@ -190,8 +191,6 @@ namespace QMK_Toolbox
             {
                 mcuBox.Items.Add(mcu);
             }
-            if (mcuBox.SelectedIndex == -1)
-                mcuBox.SelectedIndex = 0;
 
             if (Settings.Default.hexFileCollection != null)
                 filepathBox.Items.AddRange(Settings.Default.hexFileCollection.ToArray());

--- a/windows/QMK Toolbox/Properties/Settings.Designer.cs
+++ b/windows/QMK Toolbox/Properties/Settings.Designer.cs
@@ -37,7 +37,7 @@ namespace QMK_Toolbox.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.DefaultSettingValueAttribute("atmega32u4")]
         public string targetSetting {
             get {
                 return ((string)(this["targetSetting"]));

--- a/windows/QMK Toolbox/Properties/Settings.settings
+++ b/windows/QMK Toolbox/Properties/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="targetSetting" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+      <Value Profile="(Default)">atmega32u4</Value>
     </Setting>
     <Setting Name="autoSetting" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

 - The MCU dropdown now properly remembers the last one selected, and provides a default on first run (`atmega32u4`) without relying on the assumption that it's the first entry
 - The dropdown has also been changed to not be editable, to prevent users trying to empty it to flash ARM boards
 - Added some missing MCUs (16U4, USB64) and sorted the list alphabetically, now that we can 😁

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #116
