### PR TITLE
Change atmega32a to atmega32 - atmega32a does not have separate part command with avrdude

### DIFF
--- a/common/mcu-list.txt
+++ b/common/mcu-list.txt
@@ -3,4 +3,4 @@ at90usb1286
 atmega32u2
 atmega16u2
 atmega328p
-atmega32a
+atmega32


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
