### PR TITLE
Filter out more non-Caterina devices

### DIFF
--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -288,7 +288,7 @@ static kern_return_t MyGetModemPath(io_iterator_t serialPortIterator, char *devi
             if (result)
             {
                 NSString *testDevice = [NSString stringWithUTF8String:testDeviceFilePath];
-                if ([testDevice rangeOfString:@"Bluetooth"].location == NSNotFound) {
+                if ([testDevice rangeOfString:@"usbmodem"].location != NSNotFound) {
                     memcpy(deviceFilePath, testDeviceFilePath, FILEPATH_SIZE);
                     printf("BSD path: %s\n", deviceFilePath);
                     kernResult = KERN_SUCCESS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Instead of ignoring all devices containing the word `Bluetooth`, we should be ignoring ones that *don't* contain the word `usbmodem`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #109 
* Possibly #111 ?
