### PR TITLE
Better detection of pro micro device on macos X

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -9,4 +9,4 @@ Requirements:
 
 Run the following command to build a release:
 
-```./build_release.sh```
+```./build_release.command```

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -157,7 +157,7 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
 static void type##DeviceAdded(void *refCon, io_iterator_t iterator) { \
     io_service_t    object; \
     while ((object = IOIteratorNext(iterator))) { \
-        double delayInSeconds = 1.; \
+        double delayInSeconds = 2.; \
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)); \
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){ \
             [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device connected"] withType:MessageType_Bootloader]; \


### PR DESCRIPTION

## Description
On my setup (MacBook Pro (Retina, 15-inch, Mid 2015) ; Mojave , qmk toolbox 0.0.13 (1) ), programming a pro micro device (caterina bootloader) didn't work. When pressing the reset button, qmk toolbox gave 
```
*** Caterina device disconnected
*** Caterina device connected
    No modem port found, try again.
```

But looking at the /dev directory, I did see the `/dev/cu.usbmodem14101` appear.
I suspect that there is some delay in the creation of the /dev/cu.* device for some reason.

Increasing the delay fixed the issue on my machine, now I can flash my pro micro reliably.
```
*** Caterina device connected
    Found port: /dev/cu.usbmodem14101
```

While attempting to build qmk configurator I also noticed that the documentation wasn't entirely accurate, so I fixed that up too. 

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation
