### PR TITLE
Precompiled firmware download: try .bin if .hex not found

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -134,6 +134,12 @@
         
         [_printer print:[NSString stringWithFormat:@"Downloading the file: %@", url.absoluteString] withType:MessageType_Info];
         NSData * data = [NSData dataWithContentsOfURL:url];
+        if (!data) {
+            // Try .bin extension if .hex 404'd
+            url = [[url URLByDeletingPathExtension] URLByAppendingPathExtension:@"bin"];
+            [_printer print:[NSString stringWithFormat:@"No .hex file found, trying %@", url.absoluteString] withType:MessageType_Info];
+            data = [NSData dataWithContentsOfURL:url];
+        }
         if (data) {
             NSArray * paths = NSSearchPathForDirectoriesInDomains(NSDownloadsDirectory, NSUserDomainMask, YES);
             NSString * downloadsDirectory = [paths objectAtIndex:0];

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -516,25 +516,28 @@ namespace QMK_Toolbox
             {
                 string url;
                 url = filepath.Replace(filepath.Contains("qmk://") ? "qmk://" : "qmk:", "");
-                if (!Directory.Exists(Path.Combine(Application.LocalUserAppDataPath, "downloads")))
-                {
-                    Directory.CreateDirectory(Path.Combine(Application.LocalUserAppDataPath, "downloads"));
-                }
+                filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
 
                 try
                 {
                     _printer.Print($"Downloading the file: {url}", MessageType.Info);
-                    using (var wb = new WebClient())
-                    {
-                        wb.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.33 Safari/537.36");
-                        filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
-                        wb.DownloadFile(url, filepath);
-                    }
+                    DownloadFirmwareFile(url, filepath);
                 }
-                catch (Exception e)
+                catch (Exception e1)
                 {
-                    _printer.PrintResponse("Something went wrong when trying to get the default keymap file.", MessageType.Error);
-                    return;
+                    try
+                    {
+                        // Try .bin extension if hex 404'd
+                        url = Path.ChangeExtension(url, "bin");
+                        filepath = Path.ChangeExtension(filepath, "bin");
+                        _printer.Print($"No .hex file found, trying {url}", MessageType.Info);
+                        DownloadFirmwareFile(url, filepath);
+                    }
+                    catch (Exception e2)
+                    {
+                        _printer.PrintResponse("Something went wrong when trying to get the default keymap file.", MessageType.Error);
+                        return;
+                    }
                 }
                 _printer.PrintResponse($"File saved to: {filepath}", MessageType.Info);
 
@@ -577,6 +580,19 @@ namespace QMK_Toolbox
                 filepathBox.Text = filepath;
                 if (!filepathBox.Items.Contains(filepath))
                     filepathBox.Items.Add(filepath);
+            }
+        }
+
+        private void DownloadFirmwareFile(string url, string filepath)
+        {
+            if (!Directory.Exists(Path.Combine(Application.LocalUserAppDataPath, "downloads")))
+            {
+                Directory.CreateDirectory(Path.Combine(Application.LocalUserAppDataPath, "downloads"));
+            }
+            using (var wb = new WebClient())
+            {
+                wb.Headers.Add("User-Agent", "QMK Toolbox");
+                wb.DownloadFile(url, filepath);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Replaces the `.hex` extension with `.bin` if the attempt to download the former failed. Bit of a hack, but it works 👍

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #126
* Closes #62 
