### PR TITLE
Send ManagementBaseObject instance to GetComPort()

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -211,7 +211,7 @@ namespace QMK_Toolbox
             var devices = new List<UsbDeviceInfo>();
 
             ManagementObjectCollection collection;
-            using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity where DeviceID Like ""USB%"""))
+            using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
                 collection = searcher.Get();
 
             _usb.DetectBootloaderFromCollection(collection);

--- a/windows/QMK Toolbox/Program.cs
+++ b/windows/QMK Toolbox/Program.cs
@@ -74,7 +74,7 @@ namespace QMK_Toolbox
                     flasher.Usb = usb;
 
                     ManagementObjectCollection collection;
-                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity where DeviceID Like ""USB%"""))
+                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
                         collection = searcher.Get();
 
                     usb.DetectBootloaderFromCollection(collection);
@@ -89,7 +89,7 @@ namespace QMK_Toolbox
                     flasher.Usb = usb;
 
                     ManagementObjectCollection collection;
-                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity where DeviceID Like ""USB%"""))
+                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
                         collection = searcher.Get();
 
                     usb.DetectBootloaderFromCollection(collection);

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -120,7 +120,7 @@ namespace QMK_Toolbox
             {
                 foreach (var device in searcher.Get())
                 {
-                    if (device.GetPropertyValue("PNPDeviceID").ToString().Equals(instance.GetPropertyValue("PNPDeviceId").ToString()))
+                    if (device.GetPropertyValue("PNPDeviceID").ToString().Equals(instance.GetPropertyValue("PNPDeviceID").ToString()))
                     {
                         return device.GetPropertyValue("DeviceID").ToString();
                     }

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -51,7 +51,7 @@ namespace QMK_Toolbox
             if (MatchVid(deviceId, 0x03EB) && MatchPid(deviceId, 0x6124)) // Detects Atmel SAM-BA VID & PID
             {
                 deviceName = "Atmel SAM-BA";
-                _flasher.CaterinaPort = GetComPort(deviceId);
+                _flasher.CaterinaPort = GetComPort(instance);
                 _devicesAvailable[(int)Chipset.AtmelSamBa] += connected ? 1 : -1;
             }
             else if (MatchVid(deviceId, 0x03EB)) // Detects Atmel Vendor ID for other Atmel devices
@@ -62,7 +62,7 @@ namespace QMK_Toolbox
             else if (MatchVid(deviceId, 0x2341) || MatchVid(deviceId, 0x1B4F) || MatchVid(deviceId, 0x239A)) // Detects Arduino Vendor ID, Sparkfun Vendor ID, Adafruit Vendor ID
             {
                 deviceName = "Caterina";
-                _flasher.CaterinaPort = GetComPort(deviceId);
+                _flasher.CaterinaPort = GetComPort(instance);
                 _devicesAvailable[(int)Chipset.Caterina] += connected ? 1 : -1;
             }
             else if (MatchVid(deviceId, 0x16C0) && MatchPid(deviceId, 0x0478)) // Detects PJRC VID & PID
@@ -83,20 +83,20 @@ namespace QMK_Toolbox
             else if (MatchVid(deviceId, 0x16C0) && MatchPid(deviceId, 0x0483)) // Detects Arduino ISP VID & PID
             {
                 deviceName = "AVRISP";
-                _flasher.CaterinaPort = GetComPort(deviceId);
+                _flasher.CaterinaPort = GetComPort(instance);
                 _devicesAvailable[(int)Chipset.AvrIsp] += connected ? 1 : -1;
             }
             else if (MatchVid(deviceId, 0x16C0) && MatchPid(deviceId, 0x05DC)) // Detects AVR USBAsp VID & PID
             {
                 deviceName = "USBAsp";
-                _flasher.CaterinaPort = GetComPort(deviceId);
+                _flasher.CaterinaPort = GetComPort(instance);
                 _devicesAvailable[(int)Chipset.UsbAsp] += connected ? 1 : -1;
             }
             else if (MatchVid(deviceId, 0x1781) && MatchPid(deviceId, 0x0C9F)) // Detects AVR Pocket ISP VID & PID
             {
                 deviceName = "USB Tiny";
 
-                _flasher.CaterinaPort = GetComPort(deviceId);
+                _flasher.CaterinaPort = GetComPort(instance);
                 _devicesAvailable[(int)Chipset.UsbTiny] += connected ? 1 : -1;
             } 
             else if (MatchVid(deviceId, 0x16C0) && MatchPid(deviceId, 0x05DF)) // Detects Objective Development VID & PID
@@ -114,13 +114,13 @@ namespace QMK_Toolbox
             return true;
         }
 
-        public string GetComPort(string deviceId)
+        public string GetComPort(ManagementBaseObject instance)
         {
             using (var searcher = new ManagementObjectSearcher("Select * from Win32_SerialPort"))
             {
                 foreach (var device in searcher.Get())
                 {
-                    if (device.GetPropertyValue("PNPDeviceID").ToString().Equals(deviceId))
+                    if (device.GetPropertyValue("PNPDeviceID").ToString().Equals(instance.GetPropertyValue("PNPDeviceId").ToString()))
                     {
                         return device.GetPropertyValue("DeviceID").ToString();
                     }

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -116,7 +116,7 @@ namespace QMK_Toolbox
 
         public string GetComPort(ManagementBaseObject instance)
         {
-            using (var searcher = new ManagementObjectSearcher("Select * from Win32_SerialPort"))
+            using (var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_SerialPort"))
             {
                 foreach (var device in searcher.Get())
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This was due to me changing what information `deviceId` held in #129, and not realising this gets passed to `GetComPort()` 🤦‍♂ Since it no longer matched up with the `PNPDeviceId` associated with the COM port, nothing would be found. Instead let's just give `GetComPort()` the entire object so it can extract whatever it needs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #60
