### PR TITLE
Remove "enabled flashers" box

### DIFF
--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -381,48 +381,6 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <box fixedFrame="YES" borderType="line" title="Flashers enabled" translatesAutoresizingMaskIntoConstraints="NO" id="evj-nT-3rt">
-                        <rect key="frame" x="375" y="366" width="138" height="53"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <view key="contentView" id="v7y-68-qub">
-                            <rect key="frame" x="3" y="3" width="132" height="35"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cP7-9M-IMj">
-                                    <rect key="frame" x="3" y="17" width="61" height="18"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="check" title="DFU" bezelStyle="regularSquare" imagePosition="left" enabled="NO" state="on" inset="2" id="RMa-yV-bBM">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
-                                    </buttonCell>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PJa-Ql-yez">
-                                    <rect key="frame" x="3" y="1" width="61" height="18"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="check" title="STM32" bezelStyle="regularSquare" imagePosition="left" enabled="NO" state="on" inset="2" id="3zw-eS-1X4">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
-                                    </buttonCell>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A0D-sQ-QtQ">
-                                    <rect key="frame" x="63" y="17" width="61" height="18"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="check" title="Halfkay" bezelStyle="regularSquare" imagePosition="left" enabled="NO" state="on" inset="2" id="4mq-AW-gOT">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
-                                    </buttonCell>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xhz-Xi-9Hb">
-                                    <rect key="frame" x="63" y="1" width="75" height="18"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="check" title="Caterina" bezelStyle="regularSquare" imagePosition="left" enabled="NO" state="on" inset="2" id="FQM-EC-DQI">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
-                                    </buttonCell>
-                                </button>
-                            </subviews>
-                        </view>
-                    </box>
                     <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RSb-Il-mNt">
                         <rect key="frame" x="4" y="3" width="125" height="32"/>
                         <constraints>

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -44,11 +44,6 @@ namespace QMK_Toolbox {
             this.fileGroupBox = new System.Windows.Forms.GroupBox();
             this.filepathBox = new BetterComboBox();
             this.mcuBox = new System.Windows.Forms.ComboBox();
-            this.dfuCheckbox = new System.Windows.Forms.CheckBox();
-            this.caterinaCheckbox = new System.Windows.Forms.CheckBox();
-            this.halfkayCheckbox = new System.Windows.Forms.CheckBox();
-            this.stm32Checkbox = new System.Windows.Forms.CheckBox();
-            this.enabledFlasherGroupBox = new System.Windows.Forms.GroupBox();
             this.eepromResetButton = new System.Windows.Forms.Button();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -60,7 +55,6 @@ namespace QMK_Toolbox {
             this.statusStrip.SuspendLayout();
             this.qmkGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
-            this.enabledFlasherGroupBox.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.contextMenuStrip2.SuspendLayout();
             this.SuspendLayout();
@@ -306,88 +300,6 @@ namespace QMK_Toolbox {
             this.mcuBox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
             this.mcuBox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
-            // dfuCheckbox
-            // 
-            this.dfuCheckbox.AutoSize = true;
-            this.dfuCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.dfuCheckbox.Checked = true;
-            this.dfuCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.dfuCheckbox.Enabled = false;
-            this.dfuCheckbox.Location = new System.Drawing.Point(6, 12);
-            this.dfuCheckbox.Name = "dfuCheckbox";
-            this.dfuCheckbox.Size = new System.Drawing.Size(46, 16);
-            this.dfuCheckbox.TabIndex = 5;
-            this.dfuCheckbox.Tag = "Atmel AVR, Lufa";
-            this.dfuCheckbox.Text = "DFU";
-            this.dfuCheckbox.UseVisualStyleBackColor = false;
-            this.dfuCheckbox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.dfuCheckbox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
-            // 
-            // caterinaCheckbox
-            // 
-            this.caterinaCheckbox.AutoSize = true;
-            this.caterinaCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.caterinaCheckbox.Checked = true;
-            this.caterinaCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.caterinaCheckbox.Enabled = false;
-            this.caterinaCheckbox.Location = new System.Drawing.Point(66, 27);
-            this.caterinaCheckbox.Name = "caterinaCheckbox";
-            this.caterinaCheckbox.Size = new System.Drawing.Size(63, 16);
-            this.caterinaCheckbox.TabIndex = 5;
-            this.caterinaCheckbox.Tag = "Arduino, Pro micros";
-            this.caterinaCheckbox.Text = "Caterina";
-            this.caterinaCheckbox.UseVisualStyleBackColor = false;
-            this.caterinaCheckbox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.caterinaCheckbox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
-            // 
-            // halfkayCheckbox
-            // 
-            this.halfkayCheckbox.AutoSize = true;
-            this.halfkayCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.halfkayCheckbox.Checked = true;
-            this.halfkayCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.halfkayCheckbox.Enabled = false;
-            this.halfkayCheckbox.Location = new System.Drawing.Point(66, 12);
-            this.halfkayCheckbox.Name = "halfkayCheckbox";
-            this.halfkayCheckbox.Size = new System.Drawing.Size(61, 16);
-            this.halfkayCheckbox.TabIndex = 5;
-            this.halfkayCheckbox.Tag = "Teensy";
-            this.halfkayCheckbox.Text = "Halfkay";
-            this.halfkayCheckbox.UseVisualStyleBackColor = false;
-            this.halfkayCheckbox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.halfkayCheckbox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
-            // 
-            // stm32Checkbox
-            // 
-            this.stm32Checkbox.AutoSize = true;
-            this.stm32Checkbox.BackColor = System.Drawing.Color.Transparent;
-            this.stm32Checkbox.Checked = true;
-            this.stm32Checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.stm32Checkbox.Enabled = false;
-            this.stm32Checkbox.Location = new System.Drawing.Point(6, 27);
-            this.stm32Checkbox.Name = "stm32Checkbox";
-            this.stm32Checkbox.Size = new System.Drawing.Size(59, 16);
-            this.stm32Checkbox.TabIndex = 5;
-            this.stm32Checkbox.Tag = "ARM Boards";
-            this.stm32Checkbox.Text = "STM32";
-            this.stm32Checkbox.UseVisualStyleBackColor = false;
-            this.stm32Checkbox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.stm32Checkbox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
-            // 
-            // enabledFlasherGroupBox
-            // 
-            this.enabledFlasherGroupBox.Controls.Add(this.dfuCheckbox);
-            this.enabledFlasherGroupBox.Controls.Add(this.halfkayCheckbox);
-            this.enabledFlasherGroupBox.Controls.Add(this.caterinaCheckbox);
-            this.enabledFlasherGroupBox.Controls.Add(this.stm32Checkbox);
-            this.enabledFlasherGroupBox.Location = new System.Drawing.Point(456, 53);
-            this.enabledFlasherGroupBox.Name = "enabledFlasherGroupBox";
-            this.enabledFlasherGroupBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.enabledFlasherGroupBox.Size = new System.Drawing.Size(130, 44);
-            this.enabledFlasherGroupBox.TabIndex = 26;
-            this.enabledFlasherGroupBox.TabStop = false;
-            this.enabledFlasherGroupBox.Text = "Flashers enabled";
-            // 
             // eepromResetButton
             // 
             this.eepromResetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -482,7 +394,6 @@ namespace QMK_Toolbox {
             this.Controls.Add(this.flashWhenReadyCheckbox);
             this.Controls.Add(this.hidList);
             this.Controls.Add(this.eepromResetButton);
-            this.Controls.Add(this.enabledFlasherGroupBox);
             this.Controls.Add(this.fileGroupBox);
             this.Controls.Add(this.qmkGroupBox);
             this.Controls.Add(this.listHidDevicesButton);
@@ -509,8 +420,6 @@ namespace QMK_Toolbox {
             this.qmkGroupBox.PerformLayout();
             this.fileGroupBox.ResumeLayout(false);
             this.fileGroupBox.PerformLayout();
-            this.enabledFlasherGroupBox.ResumeLayout(false);
-            this.enabledFlasherGroupBox.PerformLayout();
             this.contextMenuStrip1.ResumeLayout(false);
             this.contextMenuStrip2.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -539,11 +448,6 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.Button loadKeymap;
         private System.Windows.Forms.Label keymapLabel;
         private System.Windows.Forms.GroupBox fileGroupBox;
-        private System.Windows.Forms.CheckBox dfuCheckbox;
-        private System.Windows.Forms.CheckBox caterinaCheckbox;
-        private System.Windows.Forms.CheckBox halfkayCheckbox;
-        private System.Windows.Forms.CheckBox stm32Checkbox;
-        private System.Windows.Forms.GroupBox enabledFlasherGroupBox;
         private System.Windows.Forms.Button eepromResetButton;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It's completely useless, and probably confusing for users. A better solution to the "multiple bootloader devices connected" situation would be to have a dropdown to select which one to operate on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
