### PR TITLE
Rename Reset EEPROM button to Clear EEPROM

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -87,7 +87,7 @@
     if ([[_mcuBox objectValue] isEqualToString:@""]) {
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
-        [_flasher clearEEPROM(NSString *)[_mcuBox objectValue]];
+        [_flasher clearEEPROM:(NSString *)[_mcuBox objectValue]];
     }
 }
 

--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -20,7 +20,7 @@
 @property IBOutlet NSButton * flashButton;
 @property IBOutlet NSButton * resetButton;
 @property IBOutlet NSButton * autoFlashButton;
-@property IBOutlet NSButton * eepromResetButton;
+@property IBOutlet NSButton * clearEEPROMButton;
 @property IBOutlet NSComboBox * keyboardBox;
 @property IBOutlet NSComboBox * keymapBox;
 @property IBOutlet NSButton * loadButton;
@@ -83,11 +83,11 @@
     }
 }
 
-- (IBAction) eepromResetButtonClick:(id) sender {
+- (IBAction) clearEEPROMButtonClick:(id) sender {
     if ([[_mcuBox objectValue] isEqualToString:@""]) {
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
-        [_flasher eepromReset:(NSString *)[_mcuBox objectValue]];
+        [_flasher clearEEPROM(NSString *)[_mcuBox objectValue]];
     }
 }
 

--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -16,7 +16,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
                 <outlet property="autoFlashButton" destination="TwL-TO-5Ka" id="pLB-Ll-mP5"/>
-                <outlet property="eepromResetButton" destination="RSb-Il-mNt" id="uEb-yN-jO6"/>
+                <outlet property="clearEEPROMButton" destination="RSb-Il-mNt" id="uEb-yN-jO6"/>
                 <outlet property="filepathBox" destination="fMz-rn-IEt" id="eSr-wv-y0f"/>
                 <outlet property="flashButton" destination="OKF-oG-mRx" id="3MC-L3-Hfy"/>
                 <outlet property="keyboardBox" destination="j37-hH-gaF" id="Vhv-Th-t9k"/>
@@ -429,12 +429,12 @@
                             <constraint firstAttribute="width" constant="121" id="OrW-P7-Fri"/>
                             <constraint firstAttribute="height" constant="21" id="ZJj-0M-KZ7"/>
                         </constraints>
-                        <buttonCell key="cell" type="push" title="Reset EEPROM" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aot-j7-w9r">
+                        <buttonCell key="cell" type="push" title="Clear EEPROM" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aot-j7-w9r">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="cellTitle"/>
                         </buttonCell>
                         <connections>
-                            <action selector="eepromResetButtonClick:" target="Voe-Tx-rLC" id="xaR-XN-Tf6"/>
+                            <action selector="clearEEPROMButtonClick:" target="Voe-Tx-rLC" id="xaR-XN-Tf6"/>
                         </connections>
                     </button>
                 </subviews>

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -38,7 +38,7 @@ typedef enum {
 
 - (void)flash:(NSString *)mcu withFile:(NSString *)file;
 - (void)reset:(NSString *)mcu;
-- (void)eepromReset:(NSString *)mcu;
+- (void)clearEEPROM:(NSString *)mcu;
 @property NSString * caterinaPort;
 
 @property (nonatomic, assign) id <FlashingDelegate> delegate;

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -80,13 +80,13 @@
         [self resetAtmelSAMBA];
 }
 
-- (void)eepromReset:(NSString *)mcu {
+- (void)clearEEPROM:(NSString *)mcu {
     if ([USB canFlash:DFU])
-        [self eepromResetDFU:mcu];
+        [self clearEEPROMDFU:mcu];
     if ([USB canFlash:Caterina])
-        [self eepromResetCaterina:mcu];
+        [self clearEEPROMCaterina:mcu];
     if ([USB canFlash:USBAsp])
-        [self eepromResetUSBAsp:mcu];
+        [self clearEEPROMUSBAsp:mcu];
 }
 
 - (void)flashDFU:(NSString *)mcu withFile:(NSString *)file {
@@ -104,7 +104,7 @@
     [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"reset"]];
 }
 
-- (void)eepromResetDFU:(NSString *)mcu {
+- (void)clearEEPROMDFU:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", @"--force", @"--eeprom", file]];
@@ -114,13 +114,13 @@
     [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
 }
 
-- (void)eepromResetCaterina:(NSString *)mcu {
+- (void)clearEEPROMCaterina:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
 }
 
-- (void)eepromResetUSBAsp:(NSString *)mcu {
+- (void)clearEEPROMUSBAsp:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbasp", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -169,14 +169,14 @@ namespace QMK_Toolbox
                 ResetBootloadHid();
         }
 
-        public void EepromReset(string mcu)
+        public void ClearEeprom(string mcu)
         {
             if (Usb.CanFlash(Chipset.Dfu))
-                EepromResetDfu(mcu);
+                ClearEepromDfu(mcu);
             if (Usb.CanFlash(Chipset.Caterina))
-                EepromResetCaterina(mcu);
+                ClearEepromCaterina(mcu);
             if (Usb.CanFlash(Chipset.UsbAsp))
-                EepromResetUsbAsp(mcu);
+                ClearEepromUsbAsp(mcu);
         }
 
         private void FlashDfu(string mcu, string file)
@@ -188,13 +188,13 @@ namespace QMK_Toolbox
 
         private void ResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} reset");
 
-        private void EepromResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
+        private void ClearEepromDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
 
         private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");
 
-        private void EepromResetCaterina(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
+        private void ClearEepromCaterina(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
 
-        private void EepromResetUsbAsp(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c usbasp -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
+        private void ClearEepromUsbAsp(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c usbasp -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
 
         private void FlashHalfkay(string mcu, string file) => RunProcess("teensy_loader_cli.exe", $"-mmcu={mcu} \"{file}\" -v");
 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -49,7 +49,7 @@ namespace QMK_Toolbox {
             this.halfkayCheckbox = new System.Windows.Forms.CheckBox();
             this.stm32Checkbox = new System.Windows.Forms.CheckBox();
             this.enabledFlasherGroupBox = new System.Windows.Forms.GroupBox();
-            this.eepromResetButton = new System.Windows.Forms.Button();
+            this.clearEepromButton = new System.Windows.Forms.Button();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logTextBox = new System.Windows.Forms.RichTextBox();
@@ -388,16 +388,16 @@ namespace QMK_Toolbox {
             this.enabledFlasherGroupBox.TabStop = false;
             this.enabledFlasherGroupBox.Text = "Flashers enabled";
             // 
-            // eepromResetButton
+            // clearEepromButton
             // 
-            this.eepromResetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.eepromResetButton.Location = new System.Drawing.Point(572, 566);
-            this.eepromResetButton.Name = "eepromResetButton";
-            this.eepromResetButton.Size = new System.Drawing.Size(110, 21);
-            this.eepromResetButton.TabIndex = 27;
-            this.eepromResetButton.Text = "Reset EEPROM";
-            this.eepromResetButton.UseVisualStyleBackColor = true;
-            this.eepromResetButton.Click += new System.EventHandler(this.eepromResetButton_Click);
+            this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.clearEepromButton.Location = new System.Drawing.Point(572, 566);
+            this.clearEepromButton.Name = "clearEepromButton";
+            this.clearEepromButton.Size = new System.Drawing.Size(110, 21);
+            this.clearEepromButton.TabIndex = 27;
+            this.clearEepromButton.Text = "Clear EEPROM";
+            this.clearEepromButton.UseVisualStyleBackColor = true;
+            this.clearEepromButton.Click += new System.EventHandler(this.clearEepromButton_Click);
             // 
             // contextMenuStrip1
             // 
@@ -481,7 +481,7 @@ namespace QMK_Toolbox {
             this.ContextMenuStrip = this.contextMenuStrip1;
             this.Controls.Add(this.flashWhenReadyCheckbox);
             this.Controls.Add(this.hidList);
-            this.Controls.Add(this.eepromResetButton);
+            this.Controls.Add(this.clearEepromButton);
             this.Controls.Add(this.enabledFlasherGroupBox);
             this.Controls.Add(this.fileGroupBox);
             this.Controls.Add(this.qmkGroupBox);
@@ -544,7 +544,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.CheckBox halfkayCheckbox;
         private System.Windows.Forms.CheckBox stm32Checkbox;
         private System.Windows.Forms.GroupBox enabledFlasherGroupBox;
-        private System.Windows.Forms.Button eepromResetButton;
+        private System.Windows.Forms.Button clearEepromButton;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ComboBox hidList;

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -352,11 +352,11 @@ namespace QMK_Toolbox
             }
         }
 
-        private void eepromResetButton_Click(object sender, EventArgs e)
+        private void clearEepromButton_Click(object sender, EventArgs e)
         {
             if (!InvokeRequired)
             {
-                eepromResetButton.Enabled = false;
+                clearEepromButton.Enabled = false;
 
                 if (_usb.AreDevicesAvailable())
                 {
@@ -368,7 +368,7 @@ namespace QMK_Toolbox
                     }
                     if (error == 0)
                     {
-                        _flasher.EepromReset(mcuBox.Text);
+                        _flasher.ClearEeprom(mcuBox.Text);
                     }
                 }
                 else
@@ -376,11 +376,11 @@ namespace QMK_Toolbox
                     _printer.Print("There are no devices available", MessageType.Error);
                 }
 
-                eepromResetButton.Enabled = true;
+                clearEepromButton.Enabled = true;
             }
             else
             {
-                Invoke(new Action<object, EventArgs>(eepromResetButton_Click), sender, e);
+                Invoke(new Action<object, EventArgs>(clearEepromButton_Click), sender, e);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Even though "clearing" is not *exactly* what the button does, it's probably a good idea to differentiate it from the Reset button that exits the bootloader.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
