### PR TITLE
Remove "Jump to bootloader" button

### DIFF
--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -33,8 +33,6 @@ namespace QMK_Toolbox {
             this.listHidDevicesButton = new System.Windows.Forms.Button();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.jumpToBootloaderButton = new System.Windows.Forms.Button();
-            this.sayHelloButton = new System.Windows.Forms.Button();
             this.mcuLabel = new System.Windows.Forms.Label();
             this.qmkGroupBox = new System.Windows.Forms.GroupBox();
             this.keymapLabel = new System.Windows.Forms.Label();
@@ -156,31 +154,6 @@ namespace QMK_Toolbox {
             // 
             this.toolStripStatusLabel.Name = "toolStripStatusLabel";
             this.toolStripStatusLabel.Size = new System.Drawing.Size(0, 17);
-            // 
-            // jumpToBootloaderButton
-            // 
-            this.jumpToBootloaderButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.jumpToBootloaderButton.Enabled = false;
-            this.jumpToBootloaderButton.Location = new System.Drawing.Point(97, 566);
-            this.jumpToBootloaderButton.Name = "jumpToBootloaderButton";
-            this.jumpToBootloaderButton.Size = new System.Drawing.Size(119, 21);
-            this.jumpToBootloaderButton.TabIndex = 20;
-            this.jumpToBootloaderButton.Tag = "Experimental feature for QMK boards using the hid_api branch";
-            this.jumpToBootloaderButton.Text = "Jump to Bootloader";
-            this.jumpToBootloaderButton.UseVisualStyleBackColor = true;
-            this.jumpToBootloaderButton.Click += new System.EventHandler(this.jumpToBootloaderButton_Click);
-            // 
-            // sayHelloButton
-            // 
-            this.sayHelloButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.sayHelloButton.Location = new System.Drawing.Point(12, 566);
-            this.sayHelloButton.Name = "sayHelloButton";
-            this.sayHelloButton.Size = new System.Drawing.Size(78, 21);
-            this.sayHelloButton.TabIndex = 21;
-            this.sayHelloButton.Tag = "Experimental feature for QMK boards using the hid_api branch";
-            this.sayHelloButton.Text = "Say Hello";
-            this.sayHelloButton.UseVisualStyleBackColor = true;
-            this.sayHelloButton.Click += new System.EventHandler(this.sayHelloButton_Click);
             // 
             // mcuLabel
             // 
@@ -390,8 +363,8 @@ namespace QMK_Toolbox {
             // 
             // eepromResetButton
             // 
-            this.eepromResetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.eepromResetButton.Location = new System.Drawing.Point(572, 566);
+            this.eepromResetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.eepromResetButton.Location = new System.Drawing.Point(12, 566);
             this.eepromResetButton.Name = "eepromResetButton";
             this.eepromResetButton.Size = new System.Drawing.Size(110, 21);
             this.eepromResetButton.TabIndex = 27;
@@ -455,9 +428,9 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hidList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.hidList.FormattingEnabled = true;
-            this.hidList.Location = new System.Drawing.Point(222, 568);
+            this.hidList.Location = new System.Drawing.Point(128, 568);
             this.hidList.Name = "hidList";
-            this.hidList.Size = new System.Drawing.Size(329, 20);
+            this.hidList.Size = new System.Drawing.Size(554, 20);
             this.hidList.TabIndex = 29;
             // 
             // flashWhenReadyCheckbox
@@ -486,9 +459,7 @@ namespace QMK_Toolbox {
             this.Controls.Add(this.fileGroupBox);
             this.Controls.Add(this.qmkGroupBox);
             this.Controls.Add(this.listHidDevicesButton);
-            this.Controls.Add(this.jumpToBootloaderButton);
             this.Controls.Add(this.flashButton);
-            this.Controls.Add(this.sayHelloButton);
             this.Controls.Add(this.autoflashCheckbox);
             this.Controls.Add(this.statusStrip);
             this.Controls.Add(this.logTextBox);
@@ -530,8 +501,6 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.StatusStrip statusStrip;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel;
         private System.Windows.Forms.Button listHidDevicesButton;
-        private System.Windows.Forms.Button jumpToBootloaderButton;
-        private System.Windows.Forms.Button sayHelloButton;
         private System.Windows.Forms.Label mcuLabel;
         private System.Windows.Forms.GroupBox qmkGroupBox;
         private System.Windows.Forms.ComboBox keymapBox;

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -716,66 +716,6 @@ namespace QMK_Toolbox
             ((Button)sender).Enabled = true;
         }
 
-        private void ReportWritten(bool success)
-        {
-            if (!InvokeRequired)
-            {
-                jumpToBootloaderButton.Enabled = true;
-                sayHelloButton.Enabled = true;
-                if (success)
-                {
-                    _printer.PrintResponse("Report sent sucessfully\n", MessageType.Info);
-                }
-                else
-                {
-                    _printer.PrintResponse("Report errored\n", MessageType.Error);
-                }
-            }
-            else
-            {
-                Invoke(new Action<bool>(ReportWritten), success);
-            }
-        }
-
-        private void jumpToBootloaderButton_Click(object sender, EventArgs e)
-        {
-            jumpToBootloaderButton.Enabled = false;
-            foreach (var device in _devices)
-            {
-                device.CloseDevice();
-            }
-
-            var deviceIndex = hidList.SelectedIndex;
-            _devices[deviceIndex].OpenDevice();
-            //device.Write(Encoding.ASCII.GetBytes("BOOTLOADER"), 0);
-            var data = new byte[2];
-            data[0] = 0;
-            data[1] = 0xFE;
-            var report = new HidReport(2, new HidDeviceData(data, HidDeviceData.ReadStatus.Success));
-            _devices[deviceIndex].WriteReport(report, ReportWritten);
-            _devices[deviceIndex].CloseDevice();
-            _printer.Print("Sending report", MessageType.Hid);
-        }
-
-        private void sayHelloButton_Click(object sender, EventArgs e)
-        {
-            sayHelloButton.Enabled = false;
-            foreach (var device in _devices)
-            {
-                device.CloseDevice();
-            }
-            var deviceIndex = hidList.SelectedIndex;
-            _devices[deviceIndex].OpenDevice();
-            //device.Write(Encoding.ASCII.GetBytes("BOOTLOADER"), 0);
-            var data = new byte[2];
-            data[0] = 0;
-            data[1] = 0x01;
-            var report = new HidReport(2, new HidDeviceData(data, HidDeviceData.ReadStatus.Success));
-            _devices[deviceIndex].WriteReport(report, ReportWritten);
-            _devices[deviceIndex].CloseDevice();
-            _printer.Print("Sending report", MessageType.Hid);
-        }
-
         private void clearButton_Click(object sender, EventArgs e)
         {
             logTextBox.Clear();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Removed the "jump to bootloader" button, as it doesn't work, and if it did, it'd be a security issue (see https://github.com/qmk/qmk_firmware/pull/7456). Similar goes for the "say hello" button, and again users are probably confused as to what it's for.

Moved the EEPROM clear button to the left side to match the macOS app.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
