### PR TITLE
Put back original avrdude.conf part IDs

### DIFF
--- a/common/avrdude.conf
+++ b/common/avrdude.conf
@@ -6081,7 +6081,7 @@ part parent "m649"
 #------------------------------------------------------------
 
 part
-    id               = "atmega32a";
+    id               = "m32";
     desc             = "ATmega32";
     has_jtag         = yes;
     stk500_devcode   = 0x91;
@@ -6251,6 +6251,11 @@ part
         read            = "0 0 1 1  1 0 0 0    0 0 x x  x x x x",
                           "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
       ;
+  ;
+
+part parent "m32"
+    id      = "m32a";
+    desc    = "ATmega32A";
   ;
 
 #------------------------------------------------------------
@@ -8676,7 +8681,7 @@ part
 ;
 
 part parent "m328"
-    id			= "atmega328p";
+    id			= "m328p";
     desc		= "ATmega328P";
     signature		= 0x1e 0x95 0x0F;
 
@@ -11484,7 +11489,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "atmega32u4";
+    id               = "m32u4";
     desc             = "ATmega32U4";
     signature        = 0x1e 0x95 0x87;
     usbpid           = 0x2ff4;
@@ -11675,7 +11680,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "atmega16u4";
+    id               = "m16u4";
     desc             = "ATmega16U4";
     signature        = 0x1e 0x94 0x88;
     usbpid           = 0x2ff3;
@@ -11866,7 +11871,7 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "at90usb646";
+    id               = "usb646";
     desc             = "AT90USB646";
     signature        = 0x1e 0x96 0x82;
     usbpid           = 0x2ff9;
@@ -12057,8 +12062,8 @@ part
 #------------------------------------------------------------
 # identical to AT90USB646
 
-part parent "at90usb646"
-    id               = "at90usb647";
+part parent "usb646"
+    id               = "usb647";
     desc             = "AT90USB647";
     signature        = 0x1e 0x96 0x82;
 
@@ -12070,7 +12075,7 @@ part parent "at90usb646"
 #------------------------------------------------------------
 
 part
-    id               = "at90usb1286";
+    id               = "usb1286";
     desc             = "AT90USB1286";
     signature        = 0x1e 0x97 0x82;
     usbpid           = 0x2ffb;
@@ -12261,8 +12266,8 @@ part
 #------------------------------------------------------------
 # identical to AT90USB1286
 
-part parent "at90usb1286"
-    id               = "at90usb1287";
+part parent "usb1286"
+    id               = "usb1287";
     desc             = "AT90USB1287";
     signature        = 0x1e 0x97 0x82;
 
@@ -12650,7 +12655,7 @@ part
 #        size            = 1024;
 #        num_pages       = 256;
 part
-    id               = "atmega32u2";
+    id               = "m32u2";
     desc             = "ATmega32U2";
     has_jtag         = no;
     has_debugwire    = yes;
@@ -12838,7 +12843,7 @@ part
 #        size            = 512;
 #        num_pages       = 128;
 part
-    id               = "atmega16u2";
+    id               = "m16u2";
     desc             = "ATmega16U2";
     has_jtag         = no;
     has_debugwire    = yes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It turns out [avrdude does a `strcasecmp()`](http://svn.savannah.gnu.org/viewvc/avrdude/trunk/avrdude/avrpart.c?revision=1428&view=markup#l518) on the `-p` argument against both the part ID and description to figure out what the MCU is, so we can undo all of the ID changes, except for the 32A which needs to be a child part of the ATmega32. Now this file is much closer to the shipped version.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
