### PR TITLE
[Windows] Add a menu item to retrigger driver install

### DIFF
--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -50,6 +50,7 @@ namespace QMK_Toolbox {
             this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
             this.flashWhenReadyCheckbox = new System.Windows.Forms.CheckBox();
+            this.installDriversToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip.SuspendLayout();
             this.qmkGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
@@ -286,14 +287,15 @@ namespace QMK_Toolbox {
             // contextMenuStrip1
             // 
             this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.installDriversToolStripMenuItem,
             this.aboutToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(110, 26);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(181, 70);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(109, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -356,6 +358,13 @@ namespace QMK_Toolbox {
             this.flashWhenReadyCheckbox.Text = "Flash when ready";
             this.flashWhenReadyCheckbox.UseVisualStyleBackColor = true;
             this.flashWhenReadyCheckbox.CheckedChanged += new System.EventHandler(this.flashWhenReadyCheckbox_CheckedChanged);
+            // 
+            // installDriversToolStripMenuItem
+            // 
+            this.installDriversToolStripMenuItem.Name = "installDriversToolStripMenuItem";
+            this.installDriversToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.installDriversToolStripMenuItem.Text = "Install Drivers...";
+            this.installDriversToolStripMenuItem.Click += new System.EventHandler(this.installDriversToolStripMenuItem_Click);
             // 
             // MainWindow
             // 
@@ -424,6 +433,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
         private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
         private BetterComboBox filepathBox;
+        private System.Windows.Forms.ToolStripMenuItem installDriversToolStripMenuItem;
     }
 }
 

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -732,7 +732,7 @@ namespace QMK_Toolbox
             if (Settings.Default.firstStart)
             {
                 var driverPromptResult = MessageBox.Show("Would you like to install drivers for your devices?", "Driver installation", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                if (driverPromptResult = DialogResult.Yes)
+                if (driverPromptResult == DialogResult.Yes)
                 {
                     InstallDrivers();
                 }

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -76,6 +76,8 @@ namespace QMK_Toolbox
             try
             {
                 process.Start();
+                Settings.Default.driversInstalled = true;
+                Settings.Default.Save();
                 return true;
             }
             catch (Win32Exception)
@@ -727,21 +729,27 @@ namespace QMK_Toolbox
 
         private void MainWindow_Shown(object sender, EventArgs e)
         {
-            if (!Settings.Default.firstStart) return;
-
-            var questionResult = MessageBox.Show("Would you like to install drivers for your devices?", "Driver installation", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-            if (questionResult)
+            if (Settings.Default.firstStart)
             {
-                Settings.Default.driversInstalled = InstallDrivers();
-            }
+                var driverPromptResult = MessageBox.Show("Would you like to install drivers for your devices?", "Driver installation", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (driverPromptResult = DialogResult.Yes)
+                {
+                    InstallDrivers();
+                }
 
-            Settings.Default.firstStart = false;
-            Settings.Default.Save();
+                Settings.Default.firstStart = false;
+                Settings.Default.Save();
+            }
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
         {
             (new AboutBox()).ShowDialog();
+        }
+
+        private void installDriversToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            InstallDrivers();
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since it currently only prompts on first run and never again (until you update to a new version), added a way to run it (without the prompt) after the fact, if you accidentally clicked No.
![image](https://user-images.githubusercontent.com/4781841/72401758-12080800-37a1-11ea-9840-ae9f8e5953b2.png)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
