### PR TITLE
Fix bug where disconnecting a device didn't supply a hardware ID

### DIFF
--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -39,6 +39,11 @@ namespace QMK_Toolbox
         public bool DetectBootloader(ManagementBaseObject instance, bool connected = true)
         {
             var hardwareIds = (System.String[])instance.GetPropertyValue("HardwareID");
+            if (hardwareIds == null || hardwareIds.Length == 0)
+            {
+                return false;
+            }
+
             var deviceId = hardwareIds[0];
 
             var deviceidRegex = new Regex(@"VID_([0-9A-F]+).*PID_([0-9A-F]+).*REV_([0-9A-F]+)");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Bug I struck while debugging -- in some cases it seems that when handling a device event, no `HardwareID` is specified.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
