### PR TITLE
Check that retrieved keyboards list is non-null before attempting JSO…

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -176,7 +176,6 @@
 
     [self loadMicrocontrollers];
     [self loadKeyboards];
-    [self loadKeymaps];
     [self loadRecentDocuments];
 
     [_printer print:@"QMK Toolbox (http://qmk.fm/toolbox)" withType:MessageType_Info];
@@ -232,11 +231,14 @@
 - (void)loadKeyboards {
     NSData * data = [NSData dataWithContentsOfURL:[NSURL URLWithString:@"http://compile.qmk.fm/v1/keyboards"]];
     NSError * error = nil;
-    NSArray * keyboards = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-    [_keyboardBox removeAllItems];
-    [_keyboardBox addItemsWithObjectValues:keyboards];
-    [_keyboardBox selectItemAtIndex:0];
-    _keyboardBox.enabled = YES;
+    if (data != nil) {
+        NSArray * keyboards = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+        [_keyboardBox removeAllItems];
+        [_keyboardBox addItemsWithObjectValues:keyboards];
+        [_keyboardBox selectItemAtIndex:0];
+        _keyboardBox.enabled = YES;
+        [self loadKeymaps];
+    }
 }
 
 - (void)loadKeymaps {
@@ -263,8 +265,10 @@
 }
 
 - (IBAction)loadKeymapClick:(id)sender {
-    NSString * keyboard = [[_keyboardBox objectValue] stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
-    [self setFilePath:[NSURL URLWithString:[NSString stringWithFormat:@"qmk:http://qmk.fm/compiled/%@_default.hex", keyboard]]];
+    if ([_keyboardBox numberOfItems] > 0) {
+        NSString * keyboard = [[_keyboardBox objectValue] stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+        [self setFilePath:[NSURL URLWithString:[NSString stringWithFormat:@"qmk:http://qmk.fm/compiled/%@_default.hex", keyboard]]];
+    }
 }
 
 - (IBAction)clearButtonClick:(id)sender {

--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -229,7 +229,7 @@
 }
 
 - (void)loadKeyboards {
-    NSData * data = [NSData dataWithContentsOfURL:[NSURL URLWithString:@"http://compile.qmk.fm/v1/keyboards"]];
+    NSData * data = [NSData dataWithContentsOfURL:[NSURL URLWithString:@"http://api.qmk.fm/v1/keyboards"]];
     NSError * error = nil;
     if (data != nil) {
         NSArray * keyboards = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
@@ -242,7 +242,7 @@
 }
 
 - (void)loadKeymaps {
-//    NSData * data = [NSData dataWithContentsOfURL:[NSURL URLWithString:@"http://compile.qmk.fm/v1/keyboards"]];
+//    NSData * data = [NSData dataWithContentsOfURL:[NSURL URLWithString:@"http://api.qmk.fm/v1/keyboards"]];
 //    NSError * error = nil;
 //    NSArray * keyboards = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
     [_keymapBox removeAllItems];

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -222,7 +222,6 @@ namespace QMK_Toolbox
                 SetFilePath(_filePassedIn);
 
             LoadKeyboardList();
-            LoadKeymapList();
         }
 
         private void LoadKeyboardList()
@@ -232,15 +231,18 @@ namespace QMK_Toolbox
                 using (var wc = new WebClient())
                 {
                     var json = wc.DownloadString("http://api.qmk.fm/v1/keyboards");
-                    var keyboards = JsonConvert.DeserializeObject<List<string>>(json);
-                    keyboardBox.Items.Clear();
-                    foreach (var keyboard in keyboards)
-                    {
-                        keyboardBox.Items.Add(keyboard);
+                    if (json != null) {
+                        var keyboards = JsonConvert.DeserializeObject<List<string>>(json);
+                        keyboardBox.Items.Clear();
+                        foreach (var keyboard in keyboards)
+                        {
+                            keyboardBox.Items.Add(keyboard);
+                        }
+                        if (keyboardBox.SelectedIndex == -1)
+                            keyboardBox.SelectedIndex = 0;
+                        keyboardBox.Enabled = true;
+                        LoadKeymapList();
                     }
-                    if (keyboardBox.SelectedIndex == -1)
-                        keyboardBox.SelectedIndex = 0;
-                    keyboardBox.Enabled = true;
                 }
             }
             catch (Exception e)
@@ -263,7 +265,10 @@ namespace QMK_Toolbox
 
         private void loadKeymap_Click(object sender, EventArgs e)
         {
-            SetFilePath($"qmk:https://qmk.fm/compiled/{keyboardBox.SelectedItem.ToString().Replace("/", "_")}_default.hex");
+            if (keyboardBox.Items.Count > 0)
+            {
+                SetFilePath($"qmk:https://qmk.fm/compiled/{keyboardBox.SelectedItem.ToString().Replace("/", "_")}_default.hex");
+            }
         }
 
         private void flashButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
…N deserialization

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

https://compile.qmk.fm/v1/keyboards is currently giving a 503 (EDIT: because we should actually be using http://api.qmk.fm/v1/keyboards instead). This seems to be preventing the macOS Toolbox from completing `applicationDidFinishLaunching`, as the JSON deserializer in `loadKeyboards` evidently doesn't like being asked to deserialize `nil`.

Also moved `loadKeymaps` to be dependent upon the success of `loadKeyboards`, otherwise the Load button will be enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #172
