### PR TITLE
Set --force flag for driver installation

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -67,7 +67,7 @@ namespace QMK_Toolbox
 
             var process = new Process
             {
-                StartInfo = new ProcessStartInfo(installerPath, $"--all \"{driversPath}\"")
+                StartInfo = new ProcessStartInfo(installerPath, $"--all --force \"{driversPath}\"")
                 {
                     Verb = "runas"
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For the STM32 bootloader, Windows may automatically download the STTub30 driver (DfuSe/"STM Device in DFU mode"). The driver installer needs to forcefully override it, as dfu-util will only flash with the WinUSB driver.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
