### PR TITLE
[Mac] Add new blank option as default keyboard

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -239,7 +239,6 @@
         NSArray * keyboards = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         [_keyboardBox removeAllItems];
         [_keyboardBox addItemsWithObjectValues:keyboards];
-        [_keyboardBox selectItemAtIndex:0];
         _keyboardBox.enabled = YES;
         [self loadKeymaps];
     }

--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -240,8 +240,14 @@
         [_keyboardBox removeAllItems];
         [_keyboardBox addItemsWithObjectValues:keyboards];
         _keyboardBox.enabled = YES;
+        _keyboardBox.target = self;
+        _keyboardBox.action = @selector(keyboardBoxChanged);
         [self loadKeymaps];
     }
+}
+
+- (void)keyboardBoxChanged {
+    self.loadButton.enabled = self.keyboardBox.indexOfSelectedItem != -1;
 }
 
 - (void)loadKeymaps {
@@ -255,7 +261,7 @@
 //        [_keyboardBox addItemsWithObjectValues:keyboards];
 //    }
 //    _keymapBox.enabled = YES;
-    _loadButton.enabled = YES;
+    _loadButton.enabled = NO;
 }
 
 - (void)loadRecentDocuments {

--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -169,7 +169,7 @@
                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="backgroundColor" white="0.092534722220000004" alpha="1" colorSpace="calibratedWhite"/>
                                     <size key="minSize" width="649" height="318"/>
-                                    <size key="maxSize" width="653" height="10000000"/>
+                                    <size key="maxSize" width="651" height="10000000"/>
                                     <color key="insertionPointColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <connections>
                                         <outlet property="menu" destination="H9m-Y6-elE" id="oIU-k2-DPl"/>
@@ -304,7 +304,7 @@
                             <subviews>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j37-hH-gaF">
                                     <rect key="frame" x="7" y="6" width="285" height="24"/>
-                                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="" drawsBackground="YES" completes="NO" numberOfVisibleItems="20" id="5mG-K9-oUt">
+                                    <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select a keyboard to download" drawsBackground="YES" numberOfVisibleItems="20" id="5mG-K9-oUt">
                                         <font key="font" metaFont="cellTitle"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
## Description

To prevent people from accidentally load the 1up keyboard, add a new default that can't be loaded.

![Mar-23-2020 14-48-06](https://user-images.githubusercontent.com/204212/77352890-57533380-6d16-11ea-8c70-c3b8ecd3e6a6.gif)


Somewhat relates to https://github.com/qmk/qmk_toolbox/issues/176

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
