### PR TITLE
Enable/disable reset bootloader button

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -96,9 +96,12 @@
     if ([_autoFlashButton state] == NSOnState) {
         [self flashButtonClick:NULL];
     }
+    self.resetButton.enabled = [self.flasher canReset];
 }
 
-- (void)deviceDisconnected:(Chipset)chipset {}
+- (void)deviceDisconnected:(Chipset)chipset {
+    self.resetButton.enabled = [self.flasher canReset];
+}
 
 - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
     if ([[[filename pathExtension] lowercaseString] isEqualToString:@"qmk"] ||
@@ -173,6 +176,7 @@
     _printer = [[Printing alloc] initWithTextView:_textView];
     _flasher = [[Flashing alloc] initWithPrinter:_printer];
     _flasher.delegate = self;
+    _resetButton.enabled = NO;
 
     [self loadMicrocontrollers];
     [self loadKeyboards];

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -38,6 +38,7 @@ typedef enum {
 
 - (void)flash:(NSString *)mcu withFile:(NSString *)file;
 - (void)reset:(NSString *)mcu;
+- (BOOL)canReset;
 - (void)clearEEPROM:(NSString *)mcu;
 @property NSString * caterinaPort;
 

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -80,6 +80,19 @@
         [self resetAtmelSAMBA];
 }
 
+- (BOOL)canReset {
+    NSArray<NSNumber *> *resettable = @[
+        @(DFU),
+        @(Halfkay),
+        @(AtmelSAMBA)
+    ];
+    for (NSNumber *chipset in resettable) {
+        if ([USB canFlash:(Chipset)chipset.intValue])
+            return YES;
+    }
+    return NO;
+}
+
 - (void)clearEEPROM:(NSString *)mcu {
     if ([USB canFlash:DFU])
         [self clearEEPROMDFU:mcu];

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -142,7 +142,7 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
     while ((object = IOIteratorNext(iterator))) \
     { \
         [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device disconnected"] withType:MessageType_Bootloader]; \
-        [delegate deviceDisconnected:type]; \
+        deviceDisconnected(type); \
         kr = IOObjectRelease(object); \
         if (kr != kIOReturnSuccess) \
         { \

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -2,6 +2,7 @@
 //  Copyright © 2017 Jack Humbert. This code is licensed under MIT license (see LICENSE.md for details).
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -166,6 +167,22 @@ namespace QMK_Toolbox
                 ResetBootloadHid();
             if (Usb.CanFlash(Chipset.AtmelSamBa))
                 ResetAtmelSamBa();
+        }
+
+        public bool CanReset()
+        {
+            var resettable = new List<Chipset> {
+                Chipset.Dfu,
+                Chipset.Halfkay,
+                Chipset.BootloadHid,
+                Chipset.AtmelSamBa
+            };
+            foreach (Chipset chipset in resettable)
+            {
+                if (Usb.CanFlash(chipset))
+                    return true;
+            }
+            return false;
         }
 
         public void ClearEeprom(string mcu)

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -154,6 +154,7 @@ namespace QMK_Toolbox
             _flasher = new Flashing(_printer);
             _usb = new Usb(_flasher, _printer);
             _flasher.Usb = _usb;
+            resetButton.Enabled = false;
 
             StartListeningForDeviceEvents();
         }
@@ -311,7 +312,7 @@ namespace QMK_Toolbox
                     this.Invoke((MethodInvoker)delegate
                     {
                         flashButton.Enabled = true;
-                        resetButton.Enabled = true;
+                        resetButton.Enabled = _flasher.CanReset();
                     });
 
                 }).Start();
@@ -348,7 +349,7 @@ namespace QMK_Toolbox
                 }
 
                 flashButton.Enabled = true;
-                resetButton.Enabled = true;
+                resetButton.Enabled = _flasher.CanReset();
             }
             else
             {
@@ -613,6 +614,7 @@ namespace QMK_Toolbox
 
             UpdateHidDevices(deviceDisconnected);
             (sender as ManagementEventWatcher)?.Start();
+            resetButton.Enabled = _flasher.CanReset();
         }
 
         private void StartListeningForDeviceEvents()
@@ -640,7 +642,7 @@ namespace QMK_Toolbox
             {
                 _printer.Print("Auto-flash disabled", MessageType.Info);
                 flashButton.Enabled = true;
-                resetButton.Enabled = true;
+                resetButton.Enabled = _flasher.CanReset();
             }
         }
 
@@ -729,7 +731,6 @@ namespace QMK_Toolbox
         {
             flashButton.Enabled = !flashWhenReadyCheckbox.Checked;
             autoflashCheckbox.Enabled = !flashWhenReadyCheckbox.Checked;
-            resetButton.Enabled = !flashWhenReadyCheckbox.Checked;
         }
 
         private void MainWindow_Shown(object sender, EventArgs e)


### PR DESCRIPTION
## Description

Enable/disable exit bootloader button based on if a bootloader is detected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_toolbox/issues/36#issuecomment-477426735
