### PR TITLE
Erase before clearing EEPROM

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -120,6 +120,7 @@
 - (void)clearEEPROMDFU:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
+    result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"erase", @"--force"]];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", @"--force", @"--eeprom", file]];
 }
 

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -122,6 +122,7 @@
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"erase", @"--force"]];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", @"--force", @"--eeprom", file]];
+    [_printer print:@"Please reflash device with firmware now" withType:MessageType_Bootloader];
 }
 
 - (void)flashCaterina:(NSString *)mcu withFile:(NSString *)file {

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -204,7 +204,11 @@ namespace QMK_Toolbox
 
         private void ResetDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} reset");
 
-        private void ClearEepromDfu(string mcu) => RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
+        private void ClearEepromDfu(string mcu)
+        {
+            RunProcess("dfu-programmer.exe", $"{mcu} erase --force");
+            RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
+        }
 
         private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");
 

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -208,6 +208,7 @@ namespace QMK_Toolbox
         {
             RunProcess("dfu-programmer.exe", $"{mcu} erase --force");
             RunProcess("dfu-programmer.exe", $"{mcu} flash --force --eeprom \"reset.eep\"");
+            _printer.Print("Please reflash device with firmware now", MessageType.Bootloader);
         }
 
         private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");


### PR DESCRIPTION
## Description

Rollbacks the removal of the erase command done in https://github.com/qmk/qmk_toolbox/pull/75 and adds a message to remind user to reflash firmware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_toolbox/issues/97
