### PR TITLE
[Windows] Fix crash when a HID device has no input reports

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -437,6 +437,7 @@ namespace QMK_Toolbox
         private static IEnumerable<HidDevice> GetListableDevices() =>
             HidDevices.Enumerate()
                 .Where(d => d.IsConnected)
+                .Where(device => device.Capabilities.InputReportByteLength > 0)
                 .Where(device => (ushort)device.Capabilities.UsagePage == Flashing.ConsoleUsagePage)
                 .Where(device => (ushort)device.Capabilities.Usage == Flashing.ConsoleUsage);
 


### PR DESCRIPTION
## Description

Some devices, like the XD002 keyboard with the factory firmware, have HID report descriptors which do not declare any input reports.  If such HID descriptor additionally had the vendor-defined page and usage codes which correspond to the HID console, QMK Toolbox tried to use that HID interface as a HID console, and an attempt to read the nonexistent input report caused a crash inside HidLibrary; this made using QMK Toolbox impossible when a device with such HID report descriptor is connected.

Add a check for a non-zero input report size to `GetListableDevices()` to prevent the attempt to use a HID interface without any input repors as a HID console.

The problematic HID report descriptor from the XD002 firmware is probably [this one](https://github.com/panhao4812/Attiny85_vusb_pad_test/blob/0dcafecdcf0aa9fe4ef0ece537b409e1c3df3b86/Attiny85_Test3/usbdrv/usbdrv.c#L112-L124) — it has only a single Output report defined.  I did not actually have that device available for testing, so I made [a device with a similar descriptor](https://github.com/qmk/qmk_toolbox/issues/147#issuecomment-657239786) from a LUFA sample; with that device connected I reproduced a crash with the same backtrace as [this one](https://github.com/qmk/qmk_toolbox/issues/147#issuecomment-656941056), which is fixed by the change from this PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #65
* The same problem was also discussed in #147, but that issue is a mix of different problems (another user there had a crash with a completely different backtrace).
