### PR TITLE
Improve detection and filtering of serial devices for Caterina

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -88,8 +88,8 @@
     }
 }
 
-- (void)setCaterinaPort:(NSString *)port {
-    _flasher.caterinaPort = port;
+- (void)setSerialPort:(NSString *)port {
+    _flasher.serialPort = port;
 }
 
 - (void)deviceConnected:(Chipset)chipset {

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -18,7 +18,7 @@ typedef enum {
     SparkfunVID,
     AdafruitVID,
     DogHunterVID,
-    STM32,
+    STM32DFU,
     Kiibohd,
     AVRISP,
     USBTiny,

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -12,11 +12,12 @@
 
 typedef enum {
     AtmelSAMBA,
-    DFU,
+    AtmelDFU,
     Halfkay,
     Caterina,
-    CaterinaAlt,
-    FeatherBLE32u4,
+    SparkfunVID,
+    AdafruitVID,
+    DogHunterVID,
     STM32,
     Kiibohd,
     AVRISP,
@@ -41,7 +42,7 @@ typedef enum {
 - (void)reset:(NSString *)mcu;
 - (BOOL)canReset;
 - (void)clearEEPROM:(NSString *)mcu;
-@property NSString * caterinaPort;
+@property NSString * serialPort;
 
 @property (nonatomic, assign) id <FlashingDelegate> delegate;
 

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -16,7 +16,7 @@
 @end
 
 @implementation Flashing
-@synthesize caterinaPort;
+@synthesize serialPort;
 
 - (id)initWithPrinter:(Printing *)p {
     if (self = [super init]) {
@@ -51,8 +51,8 @@
 }
 
 - (void)flash:(NSString *)mcu withFile:(NSString *)file {
-    if ([USB canFlash:DFU])
-        [self flashDFU:mcu withFile:file];
+    if ([USB canFlash:AtmelDFU])
+        [self flashAtmelDFU:mcu withFile:file];
     if ([USB canFlash:Caterina])
         [self flashCaterina:mcu withFile:file];
     if ([USB canFlash:Halfkay])
@@ -74,8 +74,8 @@
 }
 
 - (void)reset:(NSString *)mcu {
-    if ([USB canFlash:DFU])
-        [self resetDFU:mcu];
+    if ([USB canFlash:AtmelDFU])
+        [self resetAtmelDFU:mcu];
     if ([USB canFlash:Halfkay])
         [self resetHalfkay:mcu];
     if ([USB canFlash:AtmelSAMBA])
@@ -86,7 +86,7 @@
 
 - (BOOL)canReset {
     NSArray<NSNumber *> *resettable = @[
-        @(DFU),
+        @(AtmelDFU),
         @(Halfkay),
         @(AtmelSAMBA),
         @(BootloadHID)
@@ -99,15 +99,15 @@
 }
 
 - (void)clearEEPROM:(NSString *)mcu {
-    if ([USB canFlash:DFU])
-        [self clearEEPROMDFU:mcu];
+    if ([USB canFlash:AtmelDFU])
+        [self clearEEPROMAtmelDFU:mcu];
     if ([USB canFlash:Caterina])
         [self clearEEPROMCaterina:mcu];
     if ([USB canFlash:USBAsp])
         [self clearEEPROMUSBAsp:mcu];
 }
 
-- (void)flashDFU:(NSString *)mcu withFile:(NSString *)file {
+- (void)flashAtmelDFU:(NSString *)mcu withFile:(NSString *)file {
     NSString * result;
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"erase", @"--force"]];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"flash", file]];
@@ -118,11 +118,11 @@
     }
 }
 
-- (void)resetDFU:(NSString *)mcu {
+- (void)resetAtmelDFU:(NSString *)mcu {
     [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"reset"]];
 }
 
-- (void)clearEEPROMDFU:(NSString *)mcu {
+- (void)clearEEPROMAtmelDFU:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
     result = [self runProcess:@"dfu-programmer" withArgs:@[mcu, @"erase", @"--force"]];
@@ -131,13 +131,13 @@
 }
 
 - (void)flashCaterina:(NSString *)mcu withFile:(NSString *)file {
-    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
+    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", serialPort, @"-C", @"avrdude.conf"]];
 }
 
 - (void)clearEEPROMCaterina:(NSString *)mcu {
     NSString * result;
     NSString * file = [[NSBundle mainBundle] pathForResource:@"reset" ofType:@"eep"];
-    result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
+    result = [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avr109", @"-U", [NSString stringWithFormat:@"eeprom:w:%@:i", file], @"-P", serialPort, @"-C", @"avrdude.conf"]];
 }
 
 - (void)clearEEPROMUSBAsp:(NSString *)mcu {
@@ -171,11 +171,11 @@
 }
 
 - (void)flashAVRISP:(NSString *)mcu withFile:(NSString *)file {
-    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avrisp", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
+    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"avrisp", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", serialPort, @"-C", @"avrdude.conf"]];
 }
 
 - (void)flashUSBTiny:(NSString *)mcu withFile:(NSString *)file {
-    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbtiny", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", caterinaPort, @"-C", @"avrdude.conf"]];
+    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbtiny", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", serialPort, @"-C", @"avrdude.conf"]];
 }
 
 - (void)flashUSBAsp:(NSString *)mcu withFile:(NSString *)file {
@@ -183,11 +183,11 @@
 }
 
 - (void)flashAtmelSAMBAwithFile: (NSString *)file {
-    [self runProcess:@"mdloader_mac" withArgs:@[@"-p", caterinaPort, @"-D", file, @"--restart"]];
+    [self runProcess:@"mdloader_mac" withArgs:@[@"-p", serialPort, @"-D", file, @"--restart"]];
 }
 
 - (void)resetAtmelSAMBA {
-    [self runProcess:@"mdloader_mac" withArgs:@[@"-p", caterinaPort, @"--restart"]];
+    [self runProcess:@"mdloader_mac" withArgs:@[@"-p", serialPort, @"--restart"]];
 }
 
 - (void)flashBootloadHIDwithFile: (NSString *)file {

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -57,8 +57,8 @@
         [self flashCaterina:mcu withFile:file];
     if ([USB canFlash:Halfkay])
         [self flashHalfkay:mcu withFile:file];
-    if ([USB canFlash:STM32])
-        [self flashSTM32WithFile:file];
+    if ([USB canFlash:STM32DFU])
+        [self flashSTM32DFUWithFile:file];
     if ([USB canFlash:Kiibohd])
         [self flashKiibohdWithFile:file];
     if ([USB canFlash:AVRISP])
@@ -154,7 +154,7 @@
     [self runProcess:@"teensy_loader_cli" withArgs:@[[@"-mmcu=" stringByAppendingString:mcu], @"-bv"]];
 }
 
-- (void)flashSTM32WithFile:(NSString *)file {
+- (void)flashSTM32DFUWithFile:(NSString *)file {
     if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0482:df11", @"-s", @"0x8000000:leave", @"-D", file]];
     } else {

--- a/osx/qmk_toolbox/USB.h
+++ b/osx/qmk_toolbox/USB.h
@@ -16,7 +16,7 @@
 @optional
 - (void)deviceConnected:(Chipset)chipset;
 - (void)deviceDisconnected:(Chipset)chipset;
-- (void)setCaterinaPort:(NSString *)port;
+- (void)setSerialPort:(NSString *)port;
 @end
 
 @interface USB : NSObject

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -23,7 +23,7 @@ DEFINE_ITER(AtmelSAMBA);
 DEFINE_ITER(AtmelDFU);
 DEFINE_ITER(Caterina);
 DEFINE_ITER(Halfkay);
-DEFINE_ITER(STM32);
+DEFINE_ITER(STM32DFU);
 DEFINE_ITER(Kiibohd);
 DEFINE_ITER(AVRISP);
 DEFINE_ITER(USBAsp);
@@ -56,7 +56,7 @@ static int devicesAvailable[NumberOfChipsets];
     CFMutableDictionaryRef  DogHunterVIDMatchingDict;
     CFMutableDictionaryRef  AdafruitVIDMatchingDict;
     CFMutableDictionaryRef  HalfkayMatchingDict;
-    CFMutableDictionaryRef  STM32MatchingDict;
+    CFMutableDictionaryRef  STM32DFUMatchingDict;
     CFMutableDictionaryRef  KiibohdMatchingDict;
     CFMutableDictionaryRef  AVRISPMatchingDict;
     CFMutableDictionaryRef  USBAspMatchingDict;
@@ -115,7 +115,7 @@ dest##DeviceRemoved(NULL, g##dest##RemovedIter)
     VID_MATCH_MAP(0x2A03, DogHunterVID, Caterina);
     VID_MATCH_MAP(0x239A, AdafruitVID, Caterina);
     VID_PID_MATCH(0x16C0, 0x0478, Halfkay);
-    VID_PID_MATCH(0x0483, 0xDF11, STM32);
+    VID_PID_MATCH(0x0483, 0xDF11, STM32DFU);
     VID_PID_MATCH(0x1C11, 0xB007, Kiibohd);
     VID_PID_MATCH(0x16C0, 0x0483, AVRISP);
     VID_PID_MATCH(0x16C0, 0x05DC, USBAsp);
@@ -133,11 +133,11 @@ dest##DeviceRemoved(NULL, g##dest##RemovedIter)
 #define STR2(x) #x
 #define STR(x) STR2(x)
 
-#define DEVICE_EVENTS(type) \
+#define DEVICE_EVENTS(type, name) \
 static void type##DeviceAdded(void *refCon, io_iterator_t iterator) { \
     io_service_t object; \
     while ((object = IOIteratorNext(iterator))) { \
-        [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device connected"] withType:MessageType_Bootloader]; \
+        [_printer print:[NSString stringWithFormat:@"%@ %@", name, @"device connected"] withType:MessageType_Bootloader]; \
         deviceConnected(type); \
     } \
 } \
@@ -156,14 +156,14 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
         } \
     } \
 }
-#define DEVICE_EVENTS_PORT(type) \
+#define DEVICE_EVENTS_PORT(type, name) \
 static void type##DeviceAdded(void *refCon, io_iterator_t iterator) { \
     io_service_t    object; \
     while ((object = IOIteratorNext(iterator))) { \
         double delayInSeconds = 2.; \
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)); \
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){ \
-            [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device connected"] withType:MessageType_Bootloader]; \
+            [_printer print:[NSString stringWithFormat:@"%@ %@", name, @"device connected"] withType:MessageType_Bootloader]; \
             deviceConnected(type); \
             io_iterator_t serialPortIterator; \
             char deviceFilePath[FILEPATH_SIZE]; \
@@ -196,16 +196,16 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
     } \
 }
 
-DEVICE_EVENTS_PORT(AtmelSAMBA);
-DEVICE_EVENTS(AtmelDFU);
-DEVICE_EVENTS_PORT(Caterina);
-DEVICE_EVENTS(Halfkay);
-DEVICE_EVENTS(STM32);
-DEVICE_EVENTS(Kiibohd);
-DEVICE_EVENTS_PORT(AVRISP);
-DEVICE_EVENTS(USBAsp);
-DEVICE_EVENTS_PORT(USBTiny);
-DEVICE_EVENTS(BootloadHID);
+DEVICE_EVENTS_PORT(AtmelSAMBA, @"Atmel SAM-BA");
+DEVICE_EVENTS(AtmelDFU, @"Atmel DFU");
+DEVICE_EVENTS_PORT(Caterina, @"Caterina");
+DEVICE_EVENTS(Halfkay, @"Halfkay");
+DEVICE_EVENTS(STM32DFU, @"STM32 DFU");
+DEVICE_EVENTS(Kiibohd, @"Kiibohd");
+DEVICE_EVENTS_PORT(AVRISP, @"AVRISP");
+DEVICE_EVENTS(USBAsp, @"USBAsp");
+DEVICE_EVENTS_PORT(USBTiny, @"USBTiny");
+DEVICE_EVENTS(BootloadHID, @"BootloadHID");
 
 static kern_return_t MyFindModems(io_iterator_t *matchingServices)
 {

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -20,7 +20,7 @@ static io_iterator_t            g##type##RemovedIter
 //Global variables
 static IONotificationPortRef    gNotifyPort;
 DEFINE_ITER(AtmelSAMBA);
-DEFINE_ITER(DFU);
+DEFINE_ITER(AtmelDFU);
 DEFINE_ITER(Caterina);
 DEFINE_ITER(Halfkay);
 DEFINE_ITER(STM32);
@@ -50,11 +50,11 @@ static int devicesAvailable[NumberOfChipsets];
     _printer = printer;
     mach_port_t             masterPort;
     CFMutableDictionaryRef  AtmelSAMBAMatchingDict;
-    CFMutableDictionaryRef  DFUMatchingDict;
+    CFMutableDictionaryRef  AtmelDFUMatchingDict;
     CFMutableDictionaryRef  CaterinaMatchingDict;
-    CFMutableDictionaryRef  CaterinaAltMatchingDict;
-    CFMutableDictionaryRef  CaterinaDogHunterMatchingDict;
-    CFMutableDictionaryRef  FeatherBLE32u4MatchingDict;
+    CFMutableDictionaryRef  SparkfunVIDMatchingDict;
+    CFMutableDictionaryRef  DogHunterVIDMatchingDict;
+    CFMutableDictionaryRef  AdafruitVIDMatchingDict;
     CFMutableDictionaryRef  HalfkayMatchingDict;
     CFMutableDictionaryRef  STM32MatchingDict;
     CFMutableDictionaryRef  KiibohdMatchingDict;
@@ -109,11 +109,11 @@ kr = IOServiceAddMatchingNotification(gNotifyPort, kIOTerminatedNotification, ty
 dest##DeviceRemoved(NULL, g##dest##RemovedIter)
 
     VID_PID_MATCH(0x03EB, 0x6124, AtmelSAMBA);
-    VID_MATCH(0x03EB, DFU);
+    VID_MATCH(0x03EB, AtmelDFU);
     VID_MATCH(0x2341, Caterina);
-    VID_MATCH_MAP(0x1B4F, CaterinaAlt, Caterina);
-    VID_MATCH_MAP(0x2a03, CaterinaDogHunter, Caterina);
-    VID_MATCH_MAP(0x239a, FeatherBLE32u4, Caterina);
+    VID_MATCH_MAP(0x1B4F, SparkfunVID, Caterina);
+    VID_MATCH_MAP(0x2A03, DogHunterVID, Caterina);
+    VID_MATCH_MAP(0x239A, AdafruitVID, Caterina);
     VID_PID_MATCH(0x16C0, 0x0478, Halfkay);
     VID_PID_MATCH(0x0483, 0xDF11, STM32);
     VID_PID_MATCH(0x1C11, 0xB007, Kiibohd);
@@ -173,7 +173,7 @@ static void type##DeviceAdded(void *refCon, io_iterator_t iterator) { \
                 printf("No modem port found.\n"); \
                 [_printer printResponse:@"No modem port found, try again." withType:MessageType_Bootloader]; \
             } else { \
-                [delegate setCaterinaPort:[NSString stringWithFormat:@"%s", deviceFilePath]]; \
+                [delegate setSerialPort:[NSString stringWithFormat:@"%s", deviceFilePath]]; \
                 [_printer printResponse:[NSString stringWithFormat:@"Found port: %s", deviceFilePath] withType:MessageType_Bootloader]; \
             } \
             IOObjectRelease(serialPortIterator); \
@@ -197,7 +197,7 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
 }
 
 DEVICE_EVENTS_PORT(AtmelSAMBA);
-DEVICE_EVENTS(DFU);
+DEVICE_EVENTS(AtmelDFU);
 DEVICE_EVENTS_PORT(Caterina);
 DEVICE_EVENTS(Halfkay);
 DEVICE_EVENTS(STM32);

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -38,7 +38,7 @@ namespace QMK_Toolbox
 
         public const ushort ConsoleUsagePage = 0xFF31;
         public const int ConsoleUsage = 0x0074;
-        public string CaterinaPort = "";
+        public string ComPort = "";
 
         private readonly Printing _printer;
         public Usb Usb;
@@ -211,9 +211,9 @@ namespace QMK_Toolbox
             _printer.Print("Please reflash device with firmware now", MessageType.Bootloader);
         }
 
-        private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {CaterinaPort}");
+        private void FlashCaterina(string mcu, string file) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U flash:w:\"{file}\":i -P {ComPort}");
 
-        private void ClearEepromCaterina(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U eeprom:w:\"reset.eep\":i -P {CaterinaPort}");
+        private void ClearEepromCaterina(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c avr109 -U eeprom:w:\"reset.eep\":i -P {ComPort}");
 
         private void ClearEepromUsbAsp(string mcu) => RunProcess("avrdude.exe", $"-p {mcu} -c usbasp -U eeprom:w:\"reset.eep\":i");
 
@@ -241,7 +241,7 @@ namespace QMK_Toolbox
 
         private void FlashAvrIsp(string mcu, string file)
         {
-            RunProcess("avrdude.exe", $"-p {mcu} -c avrisp -U flash:w:\"{file}\":i -P {CaterinaPort}");
+            RunProcess("avrdude.exe", $"-p {mcu} -c avrisp -U flash:w:\"{file}\":i -P {ComPort}");
             _printer.Print("Flash complete", MessageType.Bootloader);
         }
 
@@ -253,15 +253,15 @@ namespace QMK_Toolbox
 
         private void FlashUsbTiny(string mcu, string file)
         {
-            RunProcess("avrdude.exe", $"-p {mcu} -c usbtiny -U flash:w:\"{file}\":i -P {CaterinaPort}");
+            RunProcess("avrdude.exe", $"-p {mcu} -c usbtiny -U flash:w:\"{file}\":i -P {ComPort}");
             _printer.Print("Flash complete", MessageType.Bootloader);
         }
 
         private void FlashBootloadHid(string file) => RunProcess("bootloadHID.exe", $"-r \"{file}\"");
         private void ResetBootloadHid() => RunProcess("bootloadHID.exe", $"-r");
 
-        private void FlashAtmelSamBa(string file) => RunProcess("mdloader_windows.exe", $"-p {CaterinaPort} -D \"{file}\" --restart");
+        private void FlashAtmelSamBa(string file) => RunProcess("mdloader_windows.exe", $"-p {ComPort} -D \"{file}\" --restart");
 
-        private void ResetAtmelSamBa() => RunProcess("mdloader_windows.exe", $"-p {CaterinaPort} --restart");
+        private void ResetAtmelSamBa() => RunProcess("mdloader_windows.exe", $"-p {ComPort} --restart");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Renamed `CaterinaPort` to `serialPort`/`ComPort` as it's used for more than just Caterina
- Clarified some of the "chipset" enum names (eg. "FeatherBLE32u4" -> "AdafruitVID")
- Gave macOS some friendly names to use for each bootloader type (otherwise things like "AtmelDFU" would be displayed)
- Improved detection of serial devices on Windows -- this is where the meat of this PR is. I've added the function `IsSerialDevice()` which looks at the Compatible IDs of the device to check whether it has the USB class 0x02, subclass 0x02 which denotes a CDC-ACM device. That still wasn't enough though, as the Arduino firmware presents a CDC-ACM serial port as well. But, there are specific PIDs used by the various known Caterina bootloaders. For example 0037 is the Arduino Micro Caterina bootloader, whereas **8**037 is the sketch.

See also: https://docs.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #42 
* Fixes #204
* Fixes #210
