### PR TITLE
Add support for Pololu A-Star

### DIFF
--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -16,6 +16,7 @@ typedef enum {
     Halfkay,
     Caterina,
     SparkfunVID,
+    PololuVID,
     AdafruitVID,
     DogHunterVID,
     STM32DFU,

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -54,6 +54,7 @@ static int devicesAvailable[NumberOfChipsets];
     CFMutableDictionaryRef  CaterinaMatchingDict;
     CFMutableDictionaryRef  SparkfunVIDMatchingDict;
     CFMutableDictionaryRef  DogHunterVIDMatchingDict;
+    CFMutableDictionaryRef  PololuVIDMatchingDict;
     CFMutableDictionaryRef  AdafruitVIDMatchingDict;
     CFMutableDictionaryRef  HalfkayMatchingDict;
     CFMutableDictionaryRef  STM32DFUMatchingDict;
@@ -112,6 +113,7 @@ dest##DeviceRemoved(NULL, g##dest##RemovedIter)
     VID_MATCH(0x03EB, AtmelDFU);
     VID_MATCH(0x2341, Caterina);
     VID_MATCH_MAP(0x1B4F, SparkfunVID, Caterina);
+    VID_MATCH_MAP(0x1FFB, PololuVID, Caterina);
     VID_MATCH_MAP(0x2A03, DogHunterVID, Caterina);
     VID_MATCH_MAP(0x239A, AdafruitVID, Caterina);
     VID_PID_MATCH(0x16C0, 0x0478, Halfkay);

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -41,6 +41,7 @@ namespace QMK_Toolbox
         private static string[] caterinaVids =
         {
             "1B4F", // Spark Fun Electronics
+            "1FFB", // Pololu Electronics
             "2341", // Arduino SA
             "239A", // Adafruit Industries LLC
             "2A03"  // dog hunter AG
@@ -55,6 +56,8 @@ namespace QMK_Toolbox
             // Arduino SA / dog hunter AG
             "0036", // Leonardo
             "0037", // Micro
+            // Pololu Electronics
+            "0101", // A-Star 32U4
             // Spark Fun Electronics
             "9203", // Pro Micro 3V3/8MHz
             "9205"  // Pro Micro 5V/16MHz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The [Pololu A-Star 32U4 Micro](https://www.pololu.com/product/3101) has its own flavour of Caterina with its own VID/PID pair.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
