### PR TITLE
Fix BootloadHID devices not being detected automatically

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -216,7 +216,7 @@ namespace QMK_Toolbox
             _printer.PrintResponse(" - USBasp (AVR ISP)\n", MessageType.Info);
 
             ManagementObjectCollection collection;
-            using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
+            using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE 'USB%'"))
                 collection = searcher.Get();
 
             _usb.DetectBootloaderFromCollection(collection);

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -633,7 +633,7 @@ namespace QMK_Toolbox
 
         private void StartManagementEventWatcher(string eventType)
         {
-            var watcher = new ManagementEventWatcher($"SELECT * FROM {eventType} WITHIN 2 WHERE TargetInstance ISA 'Win32_PnPEntity'");
+            var watcher = new ManagementEventWatcher($"SELECT * FROM {eventType} WITHIN 2 WHERE TargetInstance ISA 'Win32_PnPEntity' AND TargetInstance.DeviceID LIKE 'USB%'");
             watcher.EventArrived += DeviceEvent;
             watcher.Start();
         }

--- a/windows/QMK Toolbox/Program.cs
+++ b/windows/QMK Toolbox/Program.cs
@@ -39,7 +39,7 @@ namespace QMK_Toolbox
                     flasher.Usb = usb;
 
                     ManagementObjectCollection collection;
-                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
+                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE 'USB%'"))
                         collection = searcher.Get();
 
                     usb.DetectBootloaderFromCollection(collection);
@@ -54,7 +54,7 @@ namespace QMK_Toolbox
                     flasher.Usb = usb;
 
                     ManagementObjectCollection collection;
-                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE ""USB%"""))
+                    using (var searcher = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE 'USB%'"))
                         collection = searcher.Get();
 
                     usb.DetectBootloaderFromCollection(collection);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently BootloadHID devices must be flashed by first resetting the board, then starting Toolbox. This is because the WMI query to detect creation/deletion of PNPEntity objects apparently returns more than one result (the HID device and the USB device) but there seems to be no way to get at the next one(s) (see https://docs.microsoft.com/en-us/troubleshoot/windows-client/system-management-components/wmi-activity-event-5858-logged-with-resultcode-0x80041032). The ManagementEventWatcher only sees the HID device creation event for some reason.

This is not an issue when starting the Toolbox as the USB device is already present, and detection of existing devices is done in `MainWindow_Load()` like so:
![image](https://user-images.githubusercontent.com/4781841/93013287-58409000-f5ea-11ea-8dee-c5cf4ad9d264.png)

Thus, we should narrow down the query by specifically looking for USB devices, as we do in the above query.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
