### PR TITLE
Add Caterina PID for LilyPad

### DIFF
--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -60,7 +60,8 @@ namespace QMK_Toolbox
             "0101", // A-Star 32U4
             // Spark Fun Electronics
             "9203", // Pro Micro 3V3/8MHz
-            "9205"  // Pro Micro 5V/16MHz
+            "9205", // Pro Micro 5V/16MHz
+            "9207"  // LilyPad 3V3/8MHz (and some Pro Micro clones)
         };
 
         private static string[] atmelDfuPids =


### PR DESCRIPTION
## Description

The bootloader from the Arduino LilyPad USB board, which uses USB VID:PID of `1b4f:9207`, can also be found on some 3.3V Pro Micro clones sold on AliExpress.

One particular board which can come with that bootloader version: https://www.aliexpress.com/item/32858541477.html **(WARNING: This board is not suitable as a Pro Micro replacement in most cases — the distance between rows of pins is 2.54mm (0.1″) larger than on a normal Pro Micro).** Similar 5V boards from the same seller, however, use the much more common `2341:0036` ID.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
