### PR TITLE
Fix crash when flashing with USBTiny

### DIFF
--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -175,7 +175,7 @@
 }
 
 - (void)flashUSBTiny:(NSString *)mcu withFile:(NSString *)file {
-    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbtiny", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-P", serialPort, @"-C", @"avrdude.conf"]];
+    [self runProcess:@"avrdude" withArgs:@[@"-p", mcu, @"-c", @"usbtiny", @"-U", [NSString stringWithFormat:@"flash:w:%@:i", file], @"-C", @"avrdude.conf"]];
 }
 
 - (void)flashUSBAsp:(NSString *)mcu withFile:(NSString *)file {

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -206,7 +206,7 @@ DEVICE_EVENTS(STM32DFU, @"STM32 DFU");
 DEVICE_EVENTS(Kiibohd, @"Kiibohd");
 DEVICE_EVENTS_PORT(AVRISP, @"AVRISP");
 DEVICE_EVENTS(USBAsp, @"USBAsp");
-DEVICE_EVENTS_PORT(USBTiny, @"USBTiny");
+DEVICE_EVENTS(USBTiny, @"USBTiny");
 DEVICE_EVENTS(BootloadHID, @"BootloadHID");
 
 static kern_return_t MyFindModems(io_iterator_t *matchingServices)

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -253,7 +253,7 @@ namespace QMK_Toolbox
 
         private void FlashUsbTiny(string mcu, string file)
         {
-            RunProcess("avrdude.exe", $"-p {mcu} -c usbtiny -U flash:w:\"{file}\":i -P {ComPort}");
+            RunProcess("avrdude.exe", $"-p {mcu} -c usbtiny -U flash:w:\"{file}\":i");
             _printer.Print("Flash complete", MessageType.Bootloader);
         }
 

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -109,12 +109,6 @@ namespace QMK_Toolbox
                     _flasher.ComPort = comPort;
                     _devicesAvailable[(int)Chipset.AvrIsp] += connected ? 1 : -1;
                 }
-                else if (MatchVidPid(deviceId, 0x1781, 0x0C9F)) // AVR Pocket ISP
-                {
-                    deviceName = "USB Tiny";
-                    _flasher.ComPort = comPort;
-                    _devicesAvailable[(int)Chipset.UsbTiny] += connected ? 1 : -1;
-                }
                 else
                 {
                     return false;
@@ -149,6 +143,11 @@ namespace QMK_Toolbox
             {
                 deviceName = "USBAsp";
                 _devicesAvailable[(int)Chipset.UsbAsp] += connected ? 1 : -1;
+            }
+            else if (MatchVidPid(deviceId, 0x1781, 0x0C9F)) // AVR Pocket ISP
+            {
+                deviceName = "USB Tiny";
+                _devicesAvailable[(int)Chipset.UsbTiny] += connected ? 1 : -1;
             }
             else
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Discovered in #230. As it turns out, the USBTiny/AVR Pocket Programmer is not actually a USB serial device, so trying to pass a serial port to avrdude does not make much sense here and will cause it to fail/crash, at least on macOS.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
