### PR TITLE
[Windows] Fix crash when using file picker to select firmware in WSL filesystem

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -497,36 +497,37 @@ namespace QMK_Toolbox
 
         private void SetFilePath(string filepath)
         {
-            var uri = new Uri(filepath);
-            if (uri.Scheme == "qmk")
-            {
-                string url;
-                url = filepath.Replace(filepath.Contains("qmk://") ? "qmk://" : "qmk:", "");
-                filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
+            if (!filepath.StartsWith("\\\\wsl$")) {
+                var uri = new Uri(filepath);
+                if (uri.Scheme == "qmk")
+                {
+                    string url;
+                    url = filepath.Replace(filepath.Contains("qmk://") ? "qmk://" : "qmk:", "");
+                    filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
 
-                try
-                {
-                    _printer.Print($"Downloading the file: {url}", MessageType.Info);
-                    DownloadFirmwareFile(url, filepath);
-                }
-                catch (Exception e1)
-                {
                     try
                     {
-                        // Try .bin extension if hex 404'd
-                        url = Path.ChangeExtension(url, "bin");
-                        filepath = Path.ChangeExtension(filepath, "bin");
-                        _printer.Print($"No .hex file found, trying {url}", MessageType.Info);
+                        _printer.Print($"Downloading the file: {url}", MessageType.Info);
                         DownloadFirmwareFile(url, filepath);
                     }
-                    catch (Exception e2)
+                    catch (Exception e1)
                     {
-                        _printer.PrintResponse("Something went wrong when trying to get the default keymap file.", MessageType.Error);
-                        return;
+                        try
+                        {
+                            // Try .bin extension if hex 404'd
+                            url = Path.ChangeExtension(url, "bin");
+                            filepath = Path.ChangeExtension(filepath, "bin");
+                            _printer.Print($"No .hex file found, trying {url}", MessageType.Info);
+                            DownloadFirmwareFile(url, filepath);
+                        }
+                        catch (Exception e2)
+                        {
+                            _printer.PrintResponse("Something went wrong when trying to get the default keymap file.", MessageType.Error);
+                            return;
+                        }
                     }
+                    _printer.PrintResponse($"File saved to: {filepath}", MessageType.Info);
                 }
-                _printer.PrintResponse($"File saved to: {filepath}", MessageType.Info);
-
             }
             if (filepath.EndsWith(".qmk", true, null))
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The .NET `Uri` class has trouble parsing the `\\wsl$` "hostname", because $ is not a valid character in a hostname.
See https://github.com/microsoft/WSL/issues/4722

Luckily, we don't need to try to parse the file path as a URI if we already know it starts with `\\wsl$`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
