### PR TITLE
Add support for flashing APM32 via DFU

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -192,7 +192,7 @@
     [_printer printResponse:@" - Atmel/LUFA/QMK DFU via dfu-programmer (http://dfu-programmer.github.io/)\n" withType:MessageType_Info];
     [_printer printResponse:@" - Caterina (Arduino, Pro Micro) via avrdude (http://nongnu.org/avrdude/)\n" withType:MessageType_Info];
     [_printer printResponse:@" - Halfkay (Teensy, Ergodox EZ) via Teensy Loader (https://pjrc.com/teensy/loader_cli.html)\n" withType:MessageType_Info];
-    [_printer printResponse:@" - ARM DFU (STM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n" withType:MessageType_Info];
+    [_printer printResponse:@" - ARM DFU (STM32, APM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n" withType:MessageType_Info];
     [_printer printResponse:@" - Atmel SAM-BA (Massdrop) via Massdrop Loader (https://github.com/massdrop/mdloader)\n" withType:MessageType_Info];
     [_printer printResponse:@" - BootloadHID (Atmel, PS2AVRGB) via bootloadHID (https://www.obdev.at/products/vusb/bootloadhid.html)\n" withType:MessageType_Info];
     [_printer printResponse:@"Supported ISP flashers:\n" withType:MessageType_Info];

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -26,6 +26,7 @@ typedef enum {
     USBTiny,
     USBAsp,
     BootloadHID,
+    APM32DFU,
     NumberOfChipsets
 } Chipset;
 

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -168,7 +168,7 @@
 
 - (void)flashAPM32DFUWithFile:(NSString *)file {
     if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
-        [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"314b:0106", @"-s", @"0x8000000:leave", @"-D", file]];
+        [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"314B:0106", @"-s", @"0x8000000:leave", @"-D", file]];
     } else {
         [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
     }

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -59,6 +59,8 @@
         [self flashHalfkay:mcu withFile:file];
     if ([USB canFlash:STM32DFU])
         [self flashSTM32DFUWithFile:file];
+    if ([USB canFlash:APM32DFU])
+        [self flashSTM32DFUWithFile:file];
     if ([USB canFlash:Kiibohd])
         [self flashKiibohdWithFile:file];
     if ([USB canFlash:STM32Duino])
@@ -159,6 +161,14 @@
 - (void)flashSTM32DFUWithFile:(NSString *)file {
     if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"0483:DF11", @"-s", @"0x8000000:leave", @"-D", file]];
+    } else {
+        [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
+    }
+}
+
+- (void)flashSTM32DFUWithFile:(NSString *)file {
+    if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
+        [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"314b:0106", @"-s", @"0x8000000:leave", @"-D", file]];
     } else {
         [_printer print:@"Only firmware files in .bin format can be flashed with dfu-util!" withType:MessageType_Error];
     }

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -60,7 +60,7 @@
     if ([USB canFlash:STM32DFU])
         [self flashSTM32DFUWithFile:file];
     if ([USB canFlash:APM32DFU])
-        [self flashSTM32DFUWithFile:file];
+        [self flashAPM32DFUWithFile:file];
     if ([USB canFlash:Kiibohd])
         [self flashKiibohdWithFile:file];
     if ([USB canFlash:STM32Duino])
@@ -166,7 +166,7 @@
     }
 }
 
-- (void)flashSTM32DFUWithFile:(NSString *)file {
+- (void)flashAPM32DFUWithFile:(NSString *)file {
     if([[[file pathExtension] lowercaseString] isEqualToString:@"bin"]) {
         [self runProcess:@"dfu-util" withArgs:@[@"-a", @"0", @"-d", @"314b:0106", @"-s", @"0x8000000:leave", @"-D", file]];
     } else {

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -30,6 +30,7 @@ DEFINE_ITER(AVRISP);
 DEFINE_ITER(USBAsp);
 DEFINE_ITER(USBTiny);
 DEFINE_ITER(BootloadHID);
+DEFINE_ITER(APM32DFU);
 static Printing * _printer;
 
 @interface USB () <USBDelegate>
@@ -65,6 +66,7 @@ static int devicesAvailable[NumberOfChipsets];
     CFMutableDictionaryRef  USBAspMatchingDict;
     CFMutableDictionaryRef  USBTinyMatchingDict;
     CFMutableDictionaryRef  BootloadHIDMatchingDict;
+    CFMutableDictionaryRef  APM32DFUMatchingDict;
     CFRunLoopSourceRef      runLoopSource;
     kern_return_t           kr;
     SInt32                  usbVendor;
@@ -126,6 +128,7 @@ dest##DeviceRemoved(NULL, g##dest##RemovedIter)
     VID_PID_MATCH(0x16C0, 0x05DC, USBAsp);
     VID_PID_MATCH(0x1781, 0x0C9F, USBTiny);
     VID_PID_MATCH(0x16C0, 0x05DF, BootloadHID);
+    VID_PID_MATCH(0x314B, 0x0106, APM32DFU);
 
     //Finished with master port
     mach_port_deallocate(mach_task_self(), masterPort);
@@ -212,6 +215,7 @@ DEVICE_EVENTS_PORT(AVRISP, @"AVRISP");
 DEVICE_EVENTS(USBAsp, @"USBAsp");
 DEVICE_EVENTS(USBTiny, @"USBTiny");
 DEVICE_EVENTS(BootloadHID, @"BootloadHID");
+DEVICE_EVENTS(APM32DFU, @"APM32 DFU");
 
 static kern_return_t MyFindModems(io_iterator_t *matchingServices)
 {

--- a/osx/qmk_toolbox/main.m
+++ b/osx/qmk_toolbox/main.m
@@ -48,7 +48,7 @@ int main(int argc, const char * argv[]) {
             [_printer printResponse:@" - Atmel/LUFA/QMK DFU via dfu-programmer (http://dfu-programmer.github.io/)\n" withType:MessageType_Info];
             [_printer printResponse:@" - Caterina (Arduino, Pro Micro) via avrdude (http://nongnu.org/avrdude/)\n" withType:MessageType_Info];
             [_printer printResponse:@" - Halfkay (Teensy, Ergodox EZ) via Teensy Loader (https://pjrc.com/teensy/loader_cli.html)\n" withType:MessageType_Info];
-            [_printer printResponse:@" - ARM DFU (STM32, Kiibohd, STM32Duino) via dfu-util (http://dfu-util.sourceforge.net/)\n" withType:MessageType_Info];
+            [_printer printResponse:@" - ARM DFU (STM32, APM32, Kiibohd, STM32Duino) via dfu-util (http://dfu-util.sourceforge.net/)\n" withType:MessageType_Info];
             [_printer printResponse:@" - Atmel SAM-BA (Massdrop) via Massdrop Loader (https://github.com/massdrop/mdloader)\n" withType:MessageType_Info];
             [_printer printResponse:@" - BootloadHID (Atmel, PS2AVRGB) via bootloadHID (https://www.obdev.at/products/vusb/bootloadhid.html)\n" withType:MessageType_Info];
             [_printer printResponse:@"Supported ISP flashers:\n" withType:MessageType_Info];

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ QMK Toolbox supports the following bootloaders:
  - Atmel/LUFA/QMK DFU via [dfu-programmer](http://dfu-programmer.github.io/)
  - Caterina (Arduino, Pro Micro) via [avrdude](http://nongnu.org/avrdude/)
  - Halfkay (Teensy, Ergodox EZ) via [Teensy Loader](https://pjrc.com/teensy/loader_cli.html)
- - ARM DFU (STM32, Kiibohd, STM32duino) via [dfu-util](http://dfu-util.sourceforge.net/)
+ - ARM DFU (STM32, APM32, Kiibohd, STM32duino) via [dfu-util](http://dfu-util.sourceforge.net/)
  - Atmel SAM-BA (Massdrop) via [Massdrop Loader](https://github.com/massdrop/mdloader)
  - BootloadHID (Atmel, PS2AVRGB) via [bootloadHID](https://www.obdev.at/products/vusb/bootloadhid.html)
 

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -143,7 +143,7 @@ namespace QMK_Toolbox
                 FlashCaterina(mcu, file);
             if (Usb.CanFlash(Chipset.Halfkay))
                 FlashHalfkay(mcu, file);
-            if (Usb.CanFlash(Chipset.Stm32))
+            if (Usb.CanFlash(Chipset.Stm32Dfu))
                 FlashStm32Dfu(mcu, file);
             if (Usb.CanFlash(Chipset.Apm32Dfu))
                 FlashApm32Dfu(mcu, file);

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -246,7 +246,6 @@ namespace QMK_Toolbox
         }
 
         private void FlashApm32Dfu(string mcu, string file)
-
         {
             if (Path.GetExtension(file)?.ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-a 0 -d 314B:0106 -s 0x08000000:leave -D \"{file}\"");

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -29,7 +29,7 @@ namespace QMK_Toolbox
         BootloadHid,
         AtmelSamBa,
         Stm32Duino,
-        Apm32,
+        Apm32Dfu,
         NumberOfChipsets
     };
 
@@ -145,8 +145,8 @@ namespace QMK_Toolbox
                 FlashHalfkay(mcu, file);
             if (Usb.CanFlash(Chipset.Stm32))
                 FlashStm32Dfu(mcu, file);
-            if (Usb.CanFlash(Chipset.Apm32))
-                FlashApm32(mcu, file);
+            if (Usb.CanFlash(Chipset.Apm32Dfu))
+                FlashApm32Dfu(mcu, file);
             if (Usb.CanFlash(Chipset.Kiibohd))
                 FlashKiibohd(file);
             if (Usb.CanFlash(Chipset.AvrIsp))
@@ -245,10 +245,12 @@ namespace QMK_Toolbox
             }
         }
 
-        private void FlashApm32(string mcu, string file)
+        private void FlashApm32Dfu(string mcu, string file)
+
         {
             if (Path.GetExtension(file)?.ToLower() == ".bin") {
-                RunProcess("dfu-util.exe", $"-a 0 -d 314b:0106 -s 0x08000000:leave -D \"{file}\"");
+                RunProcess("dfu-util.exe", $"-a 0 -d 314B:0106 -s 0x08000000:leave -D \"{file}\"");
+
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
             }

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -29,6 +29,7 @@ namespace QMK_Toolbox
         BootloadHid,
         AtmelSamBa,
         Stm32Duino,
+        Apm32,
         NumberOfChipsets
     };
 
@@ -142,8 +143,10 @@ namespace QMK_Toolbox
                 FlashCaterina(mcu, file);
             if (Usb.CanFlash(Chipset.Halfkay))
                 FlashHalfkay(mcu, file);
-            if (Usb.CanFlash(Chipset.Stm32Dfu))
+            if (Usb.CanFlash(Chipset.Stm32))
                 FlashStm32Dfu(mcu, file);
+            if (Usb.CanFlash(Chipset.Apm32))
+                FlashApm32(mcu, file);
             if (Usb.CanFlash(Chipset.Kiibohd))
                 FlashKiibohd(file);
             if (Usb.CanFlash(Chipset.AvrIsp))
@@ -237,6 +240,15 @@ namespace QMK_Toolbox
         {
             if (Path.GetExtension(file)?.ToLower() == ".bin") {
                 RunProcess("dfu-util.exe", $"-a 2 -d 1EAF:0003 -R -D \"{file}\"");
+            } else {
+                _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
+            }
+        }
+
+        private void FlashApm32(string mcu, string file)
+        {
+            if (Path.GetExtension(file)?.ToLower() == ".bin") {
+                RunProcess("dfu-util.exe", $"-a 0 -d 314b:0106 -s 0x08000000:leave -D \"{file}\"");
             } else {
                 _printer.Print("Only firmware files in .bin format can be flashed with dfu-util!", MessageType.Error);
             }

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -207,7 +207,7 @@ namespace QMK_Toolbox
             _printer.PrintResponse(" - Atmel/LUFA/QMK DFU via dfu-programmer (http://dfu-programmer.github.io/)\n", MessageType.Info);
             _printer.PrintResponse(" - Caterina (Arduino, Pro Micro) via avrdude (http://nongnu.org/avrdude/)\n", MessageType.Info);
             _printer.PrintResponse(" - Halfkay (Teensy, Ergodox EZ) via Teensy Loader (https://pjrc.com/teensy/loader_cli.html)\n", MessageType.Info);
-            _printer.PrintResponse(" - ARM DFU (STM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n", MessageType.Info);
+            _printer.PrintResponse(" - ARM DFU (STM32, APM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n", MessageType.Info);
             _printer.PrintResponse(" - Atmel SAM-BA (Massdrop) via Massdrop Loader (https://github.com/massdrop/mdloader)\n", MessageType.Info);
             _printer.PrintResponse(" - BootloadHID (Atmel, PS2AVRGB) via bootloadHID (https://www.obdev.at/products/vusb/bootloadhid.html)\n", MessageType.Info);
             _printer.PrintResponse("Supported ISP flashers:\n", MessageType.Info);

--- a/windows/QMK Toolbox/Program.cs
+++ b/windows/QMK Toolbox/Program.cs
@@ -83,7 +83,7 @@ namespace QMK_Toolbox
                     printer.PrintResponse(" - Atmel/LUFA/QMK DFU via dfu-programmer (http://dfu-programmer.github.io/)\n", MessageType.Info);
                     printer.PrintResponse(" - Caterina (Arduino, Pro Micro) via avrdude (http://nongnu.org/avrdude/)\n", MessageType.Info);
                     printer.PrintResponse(" - Halfkay (Teensy, Ergodox EZ) via Teensy Loader (https://pjrc.com/teensy/loader_cli.html)\n", MessageType.Info);
-                    printer.PrintResponse(" - ARM DFU (STM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n", MessageType.Info);
+                    printer.PrintResponse(" - ARM DFU (STM32, APM32, Kiibohd, STM32duino) via dfu-util (http://dfu-util.sourceforge.net/)\n", MessageType.Info);
                     printer.PrintResponse(" - Atmel SAM-BA (Massdrop) via Massdrop Loader (https://github.com/massdrop/mdloader)\n", MessageType.Info);
                     printer.PrintResponse(" - BootloadHID (Atmel, PS2AVRGB) via bootloadHID (https://www.obdev.at/products/vusb/bootloadhid.html)\n", MessageType.Info);
                     printer.PrintResponse("Supported ISP flashers:\n", MessageType.Info);

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -129,6 +129,11 @@ namespace QMK_Toolbox
                 deviceName = "STM32 DFU";
                 _devicesAvailable[(int)Chipset.Stm32Dfu] += connected ? 1 : -1;
             }
+            else if (MatchVidPid(deviceId, 0x314b, 0x0106)) // APM32 DFU
+            {
+                deviceName = "APM32 DFU";
+                _devicesAvailable[(int)Chipset.Apm32] += connected ? 1 : -1;
+            }
             else if (MatchVidPid(deviceId, 0x1C11, 0xB007)) // Kiibohd
             {
                 deviceName = "Kiibohd";

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -129,10 +129,10 @@ namespace QMK_Toolbox
                 deviceName = "STM32 DFU";
                 _devicesAvailable[(int)Chipset.Stm32Dfu] += connected ? 1 : -1;
             }
-            else if (MatchVidPid(deviceId, 0x314b, 0x0106)) // APM32 DFU
+            else if (MatchVidPid(deviceId, 0x314B, 0x0106)) // APM32 DFU
             {
                 deviceName = "APM32 DFU";
-                _devicesAvailable[(int)Chipset.Apm32] += connected ? 1 : -1;
+                _devicesAvailable[(int)Chipset.Apm32Dfu] += connected ? 1 : -1;
             }
             else if (MatchVidPid(deviceId, 0x1C11, 0xB007)) // Kiibohd
             {

--- a/windows/QMK Toolbox/drivers.txt
+++ b/windows/QMK Toolbox/drivers.txt
@@ -4,6 +4,7 @@
 # Driver can be one of winusb,libusb,libusbk
 # Use Windows Powershell and type [guid]::NewGuid() to generate guids
 winusb,STM32 Bootloader,0483,DF11,6d98a87f-4ecf-464d-89ed-8c684d857a75
+winusb,APM32 Bootloader,314B,0106,9ff3cc31-6772-4a3f-a492-a80d91f7a853
 winusb,STM32duino Bootloader,1EAF,0003,746915ec-99d8-4a90-a722-3c85ba31e4fe
 libusbk,USBaspLoader,16C0,05DC,e69affdc-0ef0-427c-aefb-4e593c9d2724
 winusb,Kiibohd DFU Bootloader,1C11,B007,aa5a3f86-b81e-4416-89ad-0c1ea1ed63af


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add support for flashing APM32 via DFU.
These are pin compatible with STM32.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
