### PR TITLE
[macOS] Use passed friendly name for disconnect events

### DIFF
--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -148,7 +148,7 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
     io_service_t    object; \
     while ((object = IOIteratorNext(iterator))) \
     { \
-        [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device disconnected"] withType:MessageType_Bootloader]; \
+        [_printer print:[NSString stringWithFormat:@"%@ %@", name, @"device disconnected"] withType:MessageType_Bootloader]; \
         deviceDisconnected(type); \
         kr = IOObjectRelease(object); \
         if (kr != kIOReturnSuccess) \
@@ -187,7 +187,7 @@ static void type##DeviceRemoved(void *refCon, io_iterator_t iterator) { \
     io_service_t    object; \
     while ((object = IOIteratorNext(iterator))) \
     { \
-        [_printer print:[NSString stringWithFormat:@"%@ %@", @(STR(type)), @"device disconnected"] withType:MessageType_Bootloader]; \
+        [_printer print:[NSString stringWithFormat:@"%@ %@", name, @"device disconnected"] withType:MessageType_Bootloader]; \
         deviceDisconnected(type); \
         kr = IOObjectRelease(object); \
         if (kr != kIOReturnSuccess) \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I forgot to also change these for the disconnect messages in #208. This leads to the connect messages saying eg. "Atmel DFU device connected", while the disconnect message says "AtmelDFU".

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
