### PR TITLE
New ProMicro/LilyPad PID found in the wild

### DIFF
--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -62,6 +62,7 @@ namespace QMK_Toolbox
             "9203", // Pro Micro 3V3/8MHz
             "9205", // Pro Micro 5V/16MHz
             "9207"  // LilyPad 3V3/8MHz (and some Pro Micro clones)
+            "9208"  // LilyPad 3V3/8MHz (and some Pro Micro clones)
         };
 
         private static string[] atmelDfuPids =


### PR DESCRIPTION
It seems there is also a ProMicro/LilyPad variant out there with a
different PID.
https://www.reddit.com/r/olkb/comments/k001u3/pro_micro_not_being_recognized_by_qmk/

I'm not sure if PID checking is only done in the Windows code, but I couldn't find it in the MacOS code.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
