### PR TITLE
Updates the README.MD to reflect new way of installing homebrew casks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,5 +56,5 @@ For Homebrew users, it is also available as a Cask:
 
 ```sh
 $ brew tap homebrew/cask-drivers
-$ brew cask install qmk-toolbox
+$ brew install --cask qmk-toolbox
 ```


### PR DESCRIPTION
Updates the README.MD to reflect new way of installing homebrew casks.

## Description

To install a cask you no longer write `brew cask install package` but `brew install --cask package`.
This is now reflected in the README.MD.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR