### PR TITLE
Serial port detection loop

### DIFF
--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -205,9 +205,12 @@ static void deviceDisconnectedEvent(void *refCon, io_iterator_t iterator) {
             return;
         }
 
-        [NSThread sleepForTimeInterval:0.5];
-        calloutDevice = [USB calloutDeviceForDevice:device];
-        [delegate setSerialPort:calloutDevice];
+        if (connected) {
+            while (calloutDevice == nil) {
+                calloutDevice = [USB calloutDeviceForDevice:device];
+            }
+            [delegate setSerialPort:calloutDevice];
+        }
     } else if (vendorID == 0x03EB && [atmelDfuPids containsObject:[NSNumber numberWithUnsignedShort:productID]]) { // Atmel DFU
         deviceName = @"Atmel DFU";
         deviceType = AtmelDFU;

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -106,8 +106,13 @@ namespace QMK_Toolbox
                         return false;
                     }
 
-                    comPort = GetComPort(instance);
-                    _flasher.ComPort = comPort;
+                    if (connected) {
+                        while (comPort == null)
+                        {
+                            comPort = GetComPort(instance);
+                        }
+                        _flasher.ComPort = comPort;
+                    }
                 }
                 else if (vendorId == 0x03EB && atmelDfuPids.Contains(productId)) // Atmel DFU
                 {

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -106,13 +106,8 @@ namespace QMK_Toolbox
                         return false;
                     }
 
-                    if (connected) {
-                        while (comPort == null)
-                        {
-                            comPort = GetComPort(instance);
-                        }
-                        _flasher.ComPort = comPort;
-                    }
+                    comPort = GetComPort(instance);
+                    _flasher.ComPort = comPort;
                 }
                 else if (vendorId == 0x03EB && atmelDfuPids.Contains(productId)) // Atmel DFU
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is an attempt to fix a crash that occurs on macOS when the callout device does not appear within 0.5 seconds of the USB device. Instead of sleeping for that time, we just continually loop, under the assumption that a callout device *will* appear. I think this would be perfectly fine except that as far as I know this is running in the same thread as the UI - but that may be something for another day. It should not block for too long.

The logic is copied on the Windows side, although I think the COM port appears at the same time as the USB device anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
