### PR TITLE
Autoflash improvements

### DIFF
--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -60,9 +60,7 @@
         }
         if (error == 0) {
             if (self.autoFlashButton.state != NSOnState) {
-                self.flashButton.enabled = NO;
-                self.resetButton.enabled = NO;
-                self.clearEEPROMButton.enabled = NO;
+                [self disableUI];
             }
 
             [_printer print:@"Attempting to flash, please don't remove device" withType:MessageType_Bootloader];
@@ -74,9 +72,7 @@
             });
 
             if (self.autoFlashButton.state != NSOnState) {
-                self.flashButton.enabled = [_flasher canFlash];
-                self.resetButton.enabled = [_flasher canReset];
-                self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+                [self enableUI];
             }
         }
     } else {
@@ -89,17 +85,13 @@
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
         if (self.autoFlashButton.state != NSOnState) {
-            self.flashButton.enabled = NO;
-            self.resetButton.enabled = NO;
-            self.clearEEPROMButton.enabled = NO;
+            [self disableUI];
         }
 
         [_flasher reset:(NSString *)[_mcuBox objectValue]];
 
         if (self.autoFlashButton.state != NSOnState) {
-            self.flashButton.enabled = [_flasher canFlash];
-            self.resetButton.enabled = [_flasher canReset];
-            self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+            [self enableUI];
         }
     }
 }
@@ -109,17 +101,13 @@
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
         if (self.autoFlashButton.state != NSOnState) {
-            self.flashButton.enabled = NO;
-            self.resetButton.enabled = NO;
-            self.clearEEPROMButton.enabled = NO;
+            [self disableUI];
         }
 
         [_flasher clearEEPROM:(NSString *)[_mcuBox objectValue]];
 
         if (self.autoFlashButton.state != NSOnState) {
-            self.flashButton.enabled = [_flasher canFlash];
-            self.resetButton.enabled = [_flasher canReset];
-            self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+            [self enableUI];
         }
     }
 }
@@ -131,14 +119,10 @@
 - (IBAction) autoFlashButtonClick:(id)sender {
     if ([_autoFlashButton state] == NSOnState) {
         [_printer print:@"Auto-flash enabled" withType:MessageType_Info];
-        self.flashButton.enabled = NO;
-        self.resetButton.enabled = NO;
-        self.clearEEPROMButton.enabled = NO;
+        [self disableUI];
     } else {
         [_printer print:@"Auto-flash disabled" withType:MessageType_Info];
-        self.flashButton.enabled = [_flasher canFlash];
-        self.resetButton.enabled = [_flasher canReset];
-        self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+        [self enableUI];
     }
 }
 
@@ -146,12 +130,20 @@
     if ([_autoFlashButton state] == NSOnState) {
         [self flashButtonClick:NULL];
     }
-    self.flashButton.enabled = [_flasher canFlash];
-    self.resetButton.enabled = [_flasher canReset];
-    self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+    [self enableUI];
 }
 
 - (void)deviceDisconnected:(Chipset)chipset {
+    [self enableUI];
+}
+
+- (void)disableUI {
+    self.flashButton.enabled = NO;
+    self.resetButton.enabled = NO;
+    self.clearEEPROMButton.enabled = NO;
+}
+
+- (void)enableUI {
     self.flashButton.enabled = [_flasher canFlash];
     self.resetButton.enabled = [_flasher canReset];
     self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];

--- a/osx/qmk_toolbox/AppDelegate.m
+++ b/osx/qmk_toolbox/AppDelegate.m
@@ -59,14 +59,25 @@
             error++;
         }
         if (error == 0) {
-            [_printer print:@"Attempting to flash, please don't remove device" withType:MessageType_Bootloader];
+            if (self.autoFlashButton.state != NSOnState) {
+                self.flashButton.enabled = NO;
+                self.resetButton.enabled = NO;
+                self.clearEEPROMButton.enabled = NO;
+            }
 
+            [_printer print:@"Attempting to flash, please don't remove device" withType:MessageType_Bootloader];
             // this is dumb, but the delay is required to let the previous print command show up
             double delayInSeconds = .01;
             dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
             dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
                 [self->_flasher performSelector:@selector(flash:withFile:) withObject:[self->_mcuBox objectValue] withObject:[self->_filepathBox objectValue]];
             });
+
+            if (self.autoFlashButton.state != NSOnState) {
+                self.flashButton.enabled = [_flasher canFlash];
+                self.resetButton.enabled = [_flasher canReset];
+                self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+            }
         }
     } else {
         [_printer print:@"There are no devices available" withType:MessageType_Error];
@@ -77,7 +88,19 @@
     if ([[_mcuBox objectValue] isEqualToString:@""]) {
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
+        if (self.autoFlashButton.state != NSOnState) {
+            self.flashButton.enabled = NO;
+            self.resetButton.enabled = NO;
+            self.clearEEPROMButton.enabled = NO;
+        }
+
         [_flasher reset:(NSString *)[_mcuBox objectValue]];
+
+        if (self.autoFlashButton.state != NSOnState) {
+            self.flashButton.enabled = [_flasher canFlash];
+            self.resetButton.enabled = [_flasher canReset];
+            self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+        }
     }
 }
 
@@ -85,7 +108,19 @@
     if ([[_mcuBox objectValue] isEqualToString:@""]) {
         [_printer print:@"Please select a microcontroller" withType:MessageType_Error];
     } else {
+        if (self.autoFlashButton.state != NSOnState) {
+            self.flashButton.enabled = NO;
+            self.resetButton.enabled = NO;
+            self.clearEEPROMButton.enabled = NO;
+        }
+
         [_flasher clearEEPROM:(NSString *)[_mcuBox objectValue]];
+
+        if (self.autoFlashButton.state != NSOnState) {
+            self.flashButton.enabled = [_flasher canFlash];
+            self.resetButton.enabled = [_flasher canReset];
+            self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+        }
     }
 }
 
@@ -93,15 +128,33 @@
     _flasher.serialPort = port;
 }
 
+- (IBAction) autoFlashButtonClick:(id)sender {
+    if ([_autoFlashButton state] == NSOnState) {
+        [_printer print:@"Auto-flash enabled" withType:MessageType_Info];
+        self.flashButton.enabled = NO;
+        self.resetButton.enabled = NO;
+        self.clearEEPROMButton.enabled = NO;
+    } else {
+        [_printer print:@"Auto-flash disabled" withType:MessageType_Info];
+        self.flashButton.enabled = [_flasher canFlash];
+        self.resetButton.enabled = [_flasher canReset];
+        self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
+    }
+}
+
 - (void)deviceConnected:(Chipset)chipset {
     if ([_autoFlashButton state] == NSOnState) {
         [self flashButtonClick:NULL];
     }
-    self.resetButton.enabled = [self.flasher canReset];
+    self.flashButton.enabled = [_flasher canFlash];
+    self.resetButton.enabled = [_flasher canReset];
+    self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
 }
 
 - (void)deviceDisconnected:(Chipset)chipset {
-    self.resetButton.enabled = [self.flasher canReset];
+    self.flashButton.enabled = [_flasher canFlash];
+    self.resetButton.enabled = [_flasher canReset];
+    self.clearEEPROMButton.enabled = [_flasher canClearEEPROM];
 }
 
 - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
@@ -177,7 +230,6 @@
     _printer = [[Printing alloc] initWithTextView:_textView];
     _flasher = [[Flashing alloc] initWithPrinter:_printer];
     _flasher.delegate = self;
-    _resetButton.enabled = NO;
 
     [[_textView menu] addItem: [NSMenuItem separatorItem]];
     [[_textView menu] addItem: _clearMenuItem];

--- a/osx/qmk_toolbox/Base.lproj/MainMenu.xib
+++ b/osx/qmk_toolbox/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -196,7 +196,7 @@
                             <constraint firstAttribute="height" constant="21" id="0c7-uS-SRH"/>
                             <constraint firstAttribute="width" constant="75" id="mbB-cQ-ug3"/>
                         </constraints>
-                        <buttonCell key="cell" type="push" title="Exit DFU" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="euK-aj-UAI">
+                        <buttonCell key="cell" type="push" title="Exit DFU" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="euK-aj-UAI">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
                         </buttonCell>
@@ -210,7 +210,7 @@
                             <constraint firstAttribute="height" constant="21" id="igB-eN-Klh"/>
                             <constraint firstAttribute="width" constant="68" id="sS6-6I-Jy2"/>
                         </constraints>
-                        <buttonCell key="cell" type="push" title="Flash" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WBr-hK-w8Y">
+                        <buttonCell key="cell" type="push" title="Flash" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WBr-hK-w8Y">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
                         </buttonCell>
@@ -228,6 +228,9 @@
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="label" size="12"/>
                         </buttonCell>
+                        <connections>
+                            <action selector="autoFlashButtonClick:" target="Voe-Tx-rLC" id="5Rn-zn-8HN"/>
+                        </connections>
                     </button>
                     <box borderType="line" title="Local file" translatesAutoresizingMaskIntoConstraints="NO" id="t67-0j-kLe">
                         <rect key="frame" x="2" y="418" width="667" height="53"/>
@@ -383,7 +386,7 @@
                             <constraint firstAttribute="width" constant="113" id="OrW-P7-Fri"/>
                             <constraint firstAttribute="height" constant="21" id="ZJj-0M-KZ7"/>
                         </constraints>
-                        <buttonCell key="cell" type="push" title="Clear EEPROM" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aot-j7-w9r">
+                        <buttonCell key="cell" type="push" title="Clear EEPROM" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aot-j7-w9r">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
                         </buttonCell>

--- a/osx/qmk_toolbox/Flashing.h
+++ b/osx/qmk_toolbox/Flashing.h
@@ -39,8 +39,12 @@ typedef enum {
 
 - (void)flash:(NSString *)mcu withFile:(NSString *)file;
 - (void)reset:(NSString *)mcu;
-- (BOOL)canReset;
 - (void)clearEEPROM:(NSString *)mcu;
+
+- (BOOL)canFlash;
+- (BOOL)canReset;
+- (BOOL)canClearEEPROM;
+
 @property NSString * serialPort;
 
 @property (nonatomic, assign) id <FlashingDelegate> delegate;

--- a/osx/qmk_toolbox/Flashing.m
+++ b/osx/qmk_toolbox/Flashing.m
@@ -88,6 +88,19 @@
         [self resetBootloadHID];
 }
 
+- (void)clearEEPROM:(NSString *)mcu {
+    if ([USB canFlash:AtmelDFU])
+        [self clearEEPROMAtmelDFU:mcu];
+    if ([USB canFlash:Caterina])
+        [self clearEEPROMCaterina:mcu];
+    if ([USB canFlash:USBAsp])
+        [self clearEEPROMUSBAsp:mcu];
+}
+
+- (BOOL)canFlash {
+    return [USB areDevicesAvailable];
+}
+
 - (BOOL)canReset {
     NSArray<NSNumber *> *resettable = @[
         @(AtmelDFU),
@@ -102,13 +115,17 @@
     return NO;
 }
 
-- (void)clearEEPROM:(NSString *)mcu {
-    if ([USB canFlash:AtmelDFU])
-        [self clearEEPROMAtmelDFU:mcu];
-    if ([USB canFlash:Caterina])
-        [self clearEEPROMCaterina:mcu];
-    if ([USB canFlash:USBAsp])
-        [self clearEEPROMUSBAsp:mcu];
+- (BOOL)canClearEEPROM {
+    NSArray<NSNumber *> *clearable = @[
+        @(AtmelDFU),
+        @(Caterina),
+        @(USBAsp)
+    ];
+    for (NSNumber *chipset in clearable) {
+        if ([USB canFlash:(Chipset)chipset.intValue])
+            return YES;
+    }
+    return NO;
 }
 
 - (void)flashAtmelDFU:(NSString *)mcu withFile:(NSString *)file {

--- a/osx/qmk_toolbox/USB.m
+++ b/osx/qmk_toolbox/USB.m
@@ -257,11 +257,11 @@ static void deviceDisconnectedEvent(void *refCon, io_iterator_t iterator) {
     ] withType:MessageType_Bootloader];
 
     if (connected) {
-        [delegate deviceConnected:deviceType];
         devicesAvailable[deviceType]++;
+        [delegate deviceConnected:deviceType];
     } else {
-        [delegate deviceDisconnected:deviceType];
         devicesAvailable[deviceType]--;
+        [delegate deviceDisconnected:deviceType];
     }
 }
 

--- a/windows/QMK Toolbox/App.config
+++ b/windows/QMK Toolbox/App.config
@@ -12,30 +12,30 @@
   <userSettings>
 
     <QMK_Toolbox.Properties.Settings>
-        <setting name="hexFileSetting" serializeAs="String">
-            <value />
-        </setting>
-        <setting name="targetSetting" serializeAs="String">
-            <value>atmega32u4</value>
-        </setting>
-        <setting name="autoSetting" serializeAs="String">
-            <value>False</value>
-        </setting>
-        <setting name="outputZoom" serializeAs="String">
-            <value>1</value>
-        </setting>
-        <setting name="keyboard" serializeAs="String">
-            <value />
-        </setting>
-        <setting name="keymap" serializeAs="String">
-            <value />
-        </setting>
-        <setting name="firstStart" serializeAs="String">
-            <value>True</value>
-        </setting>
-        <setting name="driversInstalled" serializeAs="String">
-            <value>False</value>
-        </setting>
+      <setting name="hexFileSetting" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="targetSetting" serializeAs="String">
+        <value>atmega32u4</value>
+      </setting>
+      <setting name="autoSetting" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="outputZoom" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="keyboard" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="keymap" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="firstStart" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="driversInstalled" serializeAs="String">
+        <value>False</value>
+      </setting>
     </QMK_Toolbox.Properties.Settings>
   </userSettings>
   <runtime>

--- a/windows/QMK Toolbox/Flashing.cs
+++ b/windows/QMK Toolbox/Flashing.cs
@@ -175,6 +175,18 @@ namespace QMK_Toolbox
                 ResetAtmelSamBa();
         }
 
+        public void ClearEeprom(string mcu)
+        {
+            if (Usb.CanFlash(Chipset.AtmelDfu))
+                ClearEepromAtmelDfu(mcu);
+            if (Usb.CanFlash(Chipset.Caterina))
+                ClearEepromCaterina(mcu);
+            if (Usb.CanFlash(Chipset.UsbAsp))
+                ClearEepromUsbAsp(mcu);
+        }
+
+        public bool CanFlash() => Usb.AreDevicesAvailable();
+
         public bool CanReset()
         {
             var resettable = new List<Chipset> {
@@ -191,14 +203,20 @@ namespace QMK_Toolbox
             return false;
         }
 
-        public void ClearEeprom(string mcu)
+        public bool CanClearEeprom()
         {
-            if (Usb.CanFlash(Chipset.AtmelDfu))
-                ClearEepromAtmelDfu(mcu);
-            if (Usb.CanFlash(Chipset.Caterina))
-                ClearEepromCaterina(mcu);
-            if (Usb.CanFlash(Chipset.UsbAsp))
-                ClearEepromUsbAsp(mcu);
+            var clearable = new List<Chipset>
+            {
+                Chipset.AtmelDfu,
+                Chipset.Caterina,
+                Chipset.UsbAsp
+            };
+            foreach (Chipset chipset in clearable)
+            {
+                if (Usb.CanFlash(chipset))
+                    return true;
+            }
+            return false;
         }
 
         private void FlashAtmelDfu(string mcu, string file)

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -55,7 +55,6 @@ namespace QMK_Toolbox {
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
-            this.flashWhenReadyCheckbox = new System.Windows.Forms.CheckBox();
             this.statusStrip.SuspendLayout();
             this.qmkGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
@@ -66,6 +65,7 @@ namespace QMK_Toolbox {
             // flashButton
             // 
             this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.flashButton.Enabled = false;
             this.flashButton.Location = new System.Drawing.Point(657, 59);
             this.flashButton.Name = "flashButton";
             this.flashButton.Size = new System.Drawing.Size(57, 23);
@@ -81,7 +81,7 @@ namespace QMK_Toolbox {
             this.autoflashCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.autoflashCheckbox.AutoSize = true;
             this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.autoflashCheckbox.Location = new System.Drawing.Point(710, 86);
+            this.autoflashCheckbox.Location = new System.Drawing.Point(657, 86);
             this.autoflashCheckbox.Name = "autoflashCheckbox";
             this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
             this.autoflashCheckbox.TabIndex = 5;
@@ -100,7 +100,7 @@ namespace QMK_Toolbox {
             // openFileButton
             // 
             this.openFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.openFileButton.Location = new System.Drawing.Point(476, 19);
+            this.openFileButton.Location = new System.Drawing.Point(581, 19);
             this.openFileButton.Name = "openFileButton";
             this.openFileButton.Size = new System.Drawing.Size(64, 23);
             this.openFileButton.TabIndex = 3;
@@ -114,6 +114,7 @@ namespace QMK_Toolbox {
             // resetButton
             // 
             this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.resetButton.Enabled = false;
             this.resetButton.Location = new System.Drawing.Point(720, 59);
             this.resetButton.Name = "resetButton";
             this.resetButton.Size = new System.Drawing.Size(67, 23);
@@ -143,7 +144,7 @@ namespace QMK_Toolbox {
             // 
             this.mcuLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.mcuLabel.AutoSize = true;
-            this.mcuLabel.Location = new System.Drawing.Point(546, 0);
+            this.mcuLabel.Location = new System.Drawing.Point(648, 0);
             this.mcuLabel.Name = "mcuLabel";
             this.mcuLabel.Size = new System.Drawing.Size(84, 13);
             this.mcuLabel.TabIndex = 22;
@@ -151,21 +152,24 @@ namespace QMK_Toolbox {
             // 
             // qmkGroupBox
             // 
+            this.qmkGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.qmkGroupBox.Controls.Add(this.keymapLabel);
             this.qmkGroupBox.Controls.Add(this.keymapBox);
             this.qmkGroupBox.Controls.Add(this.keyboardBox);
             this.qmkGroupBox.Controls.Add(this.loadKeymap);
             this.qmkGroupBox.Location = new System.Drawing.Point(6, 59);
             this.qmkGroupBox.Name = "qmkGroupBox";
-            this.qmkGroupBox.Size = new System.Drawing.Size(581, 48);
+            this.qmkGroupBox.Size = new System.Drawing.Size(645, 48);
             this.qmkGroupBox.TabIndex = 23;
             this.qmkGroupBox.TabStop = false;
             this.qmkGroupBox.Text = "Keyboard from qmk.fm";
             // 
             // keymapLabel
             // 
+            this.keymapLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.keymapLabel.AutoSize = true;
-            this.keymapLabel.Location = new System.Drawing.Point(355, 0);
+            this.keymapLabel.Location = new System.Drawing.Point(457, 0);
             this.keymapLabel.Name = "keymapLabel";
             this.keymapLabel.Size = new System.Drawing.Size(45, 13);
             this.keymapLabel.TabIndex = 24;
@@ -173,14 +177,15 @@ namespace QMK_Toolbox {
             // 
             // keymapBox
             // 
+            this.keymapBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.keymapBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "keymap", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.keymapBox.Enabled = false;
             this.keymapBox.FormattingEnabled = true;
             this.keymapBox.Items.AddRange(new object[] {
             "later version!"});
-            this.keymapBox.Location = new System.Drawing.Point(353, 20);
+            this.keymapBox.Location = new System.Drawing.Point(457, 20);
             this.keymapBox.Name = "keymapBox";
-            this.keymapBox.Size = new System.Drawing.Size(152, 21);
+            this.keymapBox.Size = new System.Drawing.Size(112, 21);
             this.keymapBox.TabIndex = 4;
             this.keymapBox.Tag = "The target (MCU) of the flashing";
             this.keymapBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keymap;
@@ -189,6 +194,8 @@ namespace QMK_Toolbox {
             // 
             // keyboardBox
             // 
+            this.keyboardBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.keyboardBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.keyboardBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.keyboardBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "keyboard", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
@@ -198,7 +205,7 @@ namespace QMK_Toolbox {
             "this feature coming in"});
             this.keyboardBox.Location = new System.Drawing.Point(6, 20);
             this.keyboardBox.Name = "keyboardBox";
-            this.keyboardBox.Size = new System.Drawing.Size(341, 21);
+            this.keyboardBox.Size = new System.Drawing.Size(445, 21);
             this.keyboardBox.TabIndex = 4;
             this.keyboardBox.Tag = "The target (MCU) of the flashing";
             this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
@@ -208,8 +215,9 @@ namespace QMK_Toolbox {
             // 
             // loadKeymap
             // 
+            this.loadKeymap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.loadKeymap.Enabled = false;
-            this.loadKeymap.Location = new System.Drawing.Point(511, 19);
+            this.loadKeymap.Location = new System.Drawing.Point(575, 19);
             this.loadKeymap.Name = "loadKeymap";
             this.loadKeymap.Size = new System.Drawing.Size(64, 23);
             this.loadKeymap.TabIndex = 3;
@@ -243,7 +251,7 @@ namespace QMK_Toolbox {
             this.filepathBox.FormattingEnabled = true;
             this.filepathBox.Location = new System.Drawing.Point(6, 20);
             this.filepathBox.Name = "filepathBox";
-            this.filepathBox.Size = new System.Drawing.Size(464, 21);
+            this.filepathBox.Size = new System.Drawing.Size(569, 21);
             this.filepathBox.TabIndex = 2;
             this.filepathBox.Tag = "The path for your firmware file";
             this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
@@ -257,9 +265,9 @@ namespace QMK_Toolbox {
             this.mcuBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "targetSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.mcuBox.FormattingEnabled = true;
-            this.mcuBox.Location = new System.Drawing.Point(546, 20);
+            this.mcuBox.Location = new System.Drawing.Point(651, 20);
             this.mcuBox.Name = "mcuBox";
-            this.mcuBox.Size = new System.Drawing.Size(214, 21);
+            this.mcuBox.Size = new System.Drawing.Size(129, 21);
             this.mcuBox.TabIndex = 4;
             this.mcuBox.Tag = "The target (MCU) of the flashing";
             this.mcuBox.Text = global::QMK_Toolbox.Properties.Settings.Default.targetSetting;
@@ -269,6 +277,7 @@ namespace QMK_Toolbox {
             // clearEepromButton
             // 
             this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.clearEepromButton.Enabled = false;
             this.clearEepromButton.Location = new System.Drawing.Point(12, 613);
             this.clearEepromButton.Name = "clearEepromButton";
             this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
@@ -400,18 +409,6 @@ namespace QMK_Toolbox {
             this.hidList.Size = new System.Drawing.Size(658, 21);
             this.hidList.TabIndex = 29;
             // 
-            // flashWhenReadyCheckbox
-            // 
-            this.flashWhenReadyCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.flashWhenReadyCheckbox.AutoSize = true;
-            this.flashWhenReadyCheckbox.Location = new System.Drawing.Point(593, 86);
-            this.flashWhenReadyCheckbox.Name = "flashWhenReadyCheckbox";
-            this.flashWhenReadyCheckbox.Size = new System.Drawing.Size(109, 17);
-            this.flashWhenReadyCheckbox.TabIndex = 30;
-            this.flashWhenReadyCheckbox.Text = "Flash when ready";
-            this.flashWhenReadyCheckbox.UseVisualStyleBackColor = true;
-            this.flashWhenReadyCheckbox.CheckedChanged += new System.EventHandler(this.flashWhenReadyCheckbox_CheckedChanged);
-            // 
             // MainWindow
             // 
             this.AllowDrop = true;
@@ -419,7 +416,6 @@ namespace QMK_Toolbox {
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(799, 661);
             this.ContextMenuStrip = this.contextMenuStrip1;
-            this.Controls.Add(this.flashWhenReadyCheckbox);
             this.Controls.Add(this.hidList);
             this.Controls.Add(this.clearEepromButton);
             this.Controls.Add(this.fileGroupBox);
@@ -473,7 +469,6 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ComboBox hidList;
-        private System.Windows.Forms.CheckBox flashWhenReadyCheckbox;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
         private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
         private BetterComboBox filepathBox;

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -208,9 +208,7 @@ namespace QMK_Toolbox
                 collection = searcher.Get();
 
             _usb.DetectBootloaderFromCollection(collection);
-            flashButton.Enabled = _flasher.CanFlash();
-            resetButton.Enabled = _flasher.CanReset();
-            clearEepromButton.Enabled = _flasher.CanClearEeprom();
+            EnableUI();
 
             UpdateHidDevices(false);
 
@@ -295,12 +293,7 @@ namespace QMK_Toolbox
                         {
                             if (!autoflashCheckbox.Checked)
                             {
-                                this.Invoke((MethodInvoker)delegate
-                                {
-                                    flashButton.Enabled = false;
-                                    resetButton.Enabled = false;
-                                    clearEepromButton.Enabled = false;
-                                });
+                                this.Invoke(new Action(DisableUI));
                             }
 
                             _printer.Print("Attempting to flash, please don't remove device", MessageType.Bootloader);
@@ -308,12 +301,7 @@ namespace QMK_Toolbox
 
                             if (!autoflashCheckbox.Checked)
                             {
-                                this.Invoke((MethodInvoker)delegate
-                                {
-                                    flashButton.Enabled = _flasher.CanFlash();
-                                    resetButton.Enabled = _flasher.CanReset();
-                                    clearEepromButton.Enabled = _flasher.CanClearEeprom();
-                                });
+                                this.Invoke(new Action(EnableUI));
                             }
                         }
                     }
@@ -345,24 +333,14 @@ namespace QMK_Toolbox
                     {
                         if (!autoflashCheckbox.Checked)
                         {
-                            this.Invoke((MethodInvoker)delegate
-                            {
-                                flashButton.Enabled = false;
-                                resetButton.Enabled = false;
-                                clearEepromButton.Enabled = false;
-                            });
+                            this.Invoke(new Action(DisableUI));
                         }
 
                         _flasher.Reset(mcuBox.Text);
 
                         if (!autoflashCheckbox.Checked)
                         {
-                            this.Invoke((MethodInvoker)delegate
-                            {
-                                flashButton.Enabled = _flasher.CanFlash();
-                                resetButton.Enabled = _flasher.CanReset();
-                                clearEepromButton.Enabled = _flasher.CanClearEeprom();
-                            });
+                            this.Invoke(new Action(EnableUI));
                         }
                     }
                 }
@@ -393,24 +371,14 @@ namespace QMK_Toolbox
                     {
                         if (!autoflashCheckbox.Checked)
                         {
-                            this.Invoke((MethodInvoker)delegate
-                            {
-                                flashButton.Enabled = false;
-                                resetButton.Enabled = false;
-                                clearEepromButton.Enabled = false;
-                            });
+                            this.Invoke(new Action(DisableUI));
                         }
 
                         _flasher.ClearEeprom(mcuBox.Text);
 
                         if (!autoflashCheckbox.Checked)
                         {
-                            this.Invoke((MethodInvoker)delegate
-                            {
-                                flashButton.Enabled = _flasher.CanFlash();
-                                resetButton.Enabled = _flasher.CanReset();
-                                clearEepromButton.Enabled = _flasher.CanClearEeprom();
-                            });
+                            this.Invoke(new Action(EnableUI));
                         }
                     }
                 }
@@ -638,12 +606,7 @@ namespace QMK_Toolbox
 
             if (!autoflashCheckbox.Checked)
             {
-                this.Invoke((MethodInvoker)delegate
-                {
-                    flashButton.Enabled = _flasher.CanFlash();
-                    resetButton.Enabled = _flasher.CanReset();
-                    clearEepromButton.Enabled = _flasher.CanClearEeprom();
-                });
+                this.Invoke(new Action(EnableUI));
             }
         }
 
@@ -665,17 +628,25 @@ namespace QMK_Toolbox
             if (autoflashCheckbox.Checked)
             {
                 _printer.Print("Auto-flash enabled", MessageType.Info);
-                flashButton.Enabled = false;
-                resetButton.Enabled = false;
-                clearEepromButton.Enabled = false;
+                DisableUI();
             }
             else
             {
                 _printer.Print("Auto-flash disabled", MessageType.Info);
-                flashButton.Enabled = _flasher.CanFlash();
-                resetButton.Enabled = _flasher.CanReset();
-                clearEepromButton.Enabled = _flasher.CanClearEeprom();
+                EnableUI();
             }
+        }
+
+        private void DisableUI() {
+            flashButton.Enabled = false;
+            resetButton.Enabled = false;
+            clearEepromButton.Enabled = false;
+        }
+
+        private void EnableUI() {
+            flashButton.Enabled = _flasher.CanFlash();
+            resetButton.Enabled = _flasher.CanReset();
+            clearEepromButton.Enabled = _flasher.CanClearEeprom();
         }
 
         // Set the button's status tip.

--- a/windows/QMK Toolbox/Properties/Settings.Designer.cs
+++ b/windows/QMK Toolbox/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace QMK_Toolbox.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Fixes some UI inconsistencies surrounding enabling/disabling of the Flash, Exit DFU and Clear EEPROM buttons.
* Auto-flash now works again on macOS.
* Removed "Flash when ready" button on Windows. Seems to be a one-time autoflash? The remaining checkbox could potentially do double duty here, using the indeterminate state and clearing once a single flash is complete.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #256
