### PR TITLE
[Windows] Add menu bar

### DIFF
--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -35,7 +35,7 @@ namespace QMK_Toolbox {
             this.keymapLabel = new System.Windows.Forms.Label();
             this.keymapBox = new System.Windows.Forms.ComboBox();
             this.keyboardBox = new System.Windows.Forms.ComboBox();
-            this.loadKeymap = new System.Windows.Forms.Button();
+            this.loadKeymapButton = new System.Windows.Forms.Button();
             this.fileGroupBox = new System.Windows.Forms.GroupBox();
             this.filepathBox = new QMK_Toolbox.BetterComboBox();
             this.mcuBox = new System.Windows.Forms.ComboBox();
@@ -136,7 +136,7 @@ namespace QMK_Toolbox {
             this.qmkfmGroupBox.Controls.Add(this.keymapLabel);
             this.qmkfmGroupBox.Controls.Add(this.keymapBox);
             this.qmkfmGroupBox.Controls.Add(this.keyboardBox);
-            this.qmkfmGroupBox.Controls.Add(this.loadKeymap);
+            this.qmkfmGroupBox.Controls.Add(this.loadKeymapButton);
             this.qmkfmGroupBox.Location = new System.Drawing.Point(12, 66);
             this.qmkfmGroupBox.Name = "qmkfmGroupBox";
             this.qmkfmGroupBox.Size = new System.Drawing.Size(635, 48);
@@ -186,17 +186,17 @@ namespace QMK_Toolbox {
             this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
             this.keyboardBox.TextChanged += new System.EventHandler(this.keyboardBox_TextChanged);
             // 
-            // loadKeymap
+            // loadKeymapButton
             // 
-            this.loadKeymap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.loadKeymap.Enabled = false;
-            this.loadKeymap.Location = new System.Drawing.Point(565, 18);
-            this.loadKeymap.Name = "loadKeymap";
-            this.loadKeymap.Size = new System.Drawing.Size(64, 23);
-            this.loadKeymap.TabIndex = 3;
-            this.loadKeymap.Text = "Load";
-            this.loadKeymap.UseVisualStyleBackColor = true;
-            this.loadKeymap.Click += new System.EventHandler(this.loadKeymap_Click);
+            this.loadKeymapButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.loadKeymapButton.Enabled = false;
+            this.loadKeymapButton.Location = new System.Drawing.Point(565, 18);
+            this.loadKeymapButton.Name = "loadKeymapButton";
+            this.loadKeymapButton.Size = new System.Drawing.Size(64, 23);
+            this.loadKeymapButton.TabIndex = 3;
+            this.loadKeymapButton.Text = "Load";
+            this.loadKeymapButton.UseVisualStyleBackColor = true;
+            this.loadKeymapButton.Click += new System.EventHandler(this.loadKeymapButton_Click);
             // 
             // fileGroupBox
             // 
@@ -286,7 +286,7 @@ namespace QMK_Toolbox {
             this.logContextMenu.Name = "contextMenuStrip2";
             this.logContextMenu.ShowImageMargin = false;
             this.logContextMenu.Size = new System.Drawing.Size(140, 126);
-            this.logContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip2_Opening);
+            this.logContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.logContextMenuStrip_Opening);
             // 
             // cutToolStripMenuItem
             // 
@@ -486,7 +486,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.GroupBox qmkfmGroupBox;
         private System.Windows.Forms.ComboBox keymapBox;
         private System.Windows.Forms.ComboBox keyboardBox;
-        private System.Windows.Forms.Button loadKeymap;
+        private System.Windows.Forms.Button loadKeymapButton;
         private System.Windows.Forms.Label keymapLabel;
         private System.Windows.Forms.GroupBox fileGroupBox;
         private System.Windows.Forms.Button clearEepromButton;

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -37,7 +37,6 @@ namespace QMK_Toolbox {
             this.keyboardBox = new System.Windows.Forms.ComboBox();
             this.loadKeymapButton = new System.Windows.Forms.Button();
             this.fileGroupBox = new System.Windows.Forms.GroupBox();
-            this.filepathBox = new QMK_Toolbox.BetterComboBox();
             this.mcuBox = new System.Windows.Forms.ComboBox();
             this.clearEepromButton = new System.Windows.Forms.Button();
             this.logTextBox = new System.Windows.Forms.RichTextBox();
@@ -50,29 +49,31 @@ namespace QMK_Toolbox {
             this.logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
             this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
-            this.mainMenu = new System.Windows.Forms.MainMenu(this.components);
-            this.fileMenuItem = new System.Windows.Forms.MenuItem();
-            this.openMenuItem = new System.Windows.Forms.MenuItem();
-            this.fileMenuSep = new System.Windows.Forms.MenuItem();
-            this.exitMenuItem = new System.Windows.Forms.MenuItem();
-            this.toolsMenuItem = new System.Windows.Forms.MenuItem();
-            this.installDriversMenuItem = new System.Windows.Forms.MenuItem();
-            this.toolsMenuSep = new System.Windows.Forms.MenuItem();
-            this.optionsMenuItem = new System.Windows.Forms.MenuItem();
-            this.helpMenuItem = new System.Windows.Forms.MenuItem();
-            this.checkForUpdatesMenuItem = new System.Windows.Forms.MenuItem();
-            this.helpMenuSep = new System.Windows.Forms.MenuItem();
-            this.aboutMenuItem = new System.Windows.Forms.MenuItem();
+            this.mainMenu = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.installDriversToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolsToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.filepathBox = new QMK_Toolbox.BetterComboBox();
             this.qmkfmGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
             this.logContextMenu.SuspendLayout();
+            this.mainMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // flashButton
             // 
             this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.flashButton.Enabled = false;
-            this.flashButton.Location = new System.Drawing.Point(653, 66);
+            this.flashButton.Location = new System.Drawing.Point(653, 86);
             this.flashButton.Name = "flashButton";
             this.flashButton.Size = new System.Drawing.Size(62, 23);
             this.flashButton.TabIndex = 6;
@@ -84,7 +85,7 @@ namespace QMK_Toolbox {
             this.autoflashCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.autoflashCheckbox.AutoSize = true;
             this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.autoflashCheckbox.Location = new System.Drawing.Point(653, 95);
+            this.autoflashCheckbox.Location = new System.Drawing.Point(653, 115);
             this.autoflashCheckbox.Name = "autoflashCheckbox";
             this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
             this.autoflashCheckbox.TabIndex = 5;
@@ -112,7 +113,7 @@ namespace QMK_Toolbox {
             // 
             this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.resetButton.Enabled = false;
-            this.resetButton.Location = new System.Drawing.Point(721, 66);
+            this.resetButton.Location = new System.Drawing.Point(721, 86);
             this.resetButton.Name = "resetButton";
             this.resetButton.Size = new System.Drawing.Size(67, 23);
             this.resetButton.TabIndex = 7;
@@ -137,7 +138,7 @@ namespace QMK_Toolbox {
             this.qmkfmGroupBox.Controls.Add(this.keymapBox);
             this.qmkfmGroupBox.Controls.Add(this.keyboardBox);
             this.qmkfmGroupBox.Controls.Add(this.loadKeymapButton);
-            this.qmkfmGroupBox.Location = new System.Drawing.Point(12, 66);
+            this.qmkfmGroupBox.Location = new System.Drawing.Point(12, 86);
             this.qmkfmGroupBox.Name = "qmkfmGroupBox";
             this.qmkfmGroupBox.Size = new System.Drawing.Size(635, 48);
             this.qmkfmGroupBox.TabIndex = 23;
@@ -206,25 +207,12 @@ namespace QMK_Toolbox {
             this.fileGroupBox.Controls.Add(this.filepathBox);
             this.fileGroupBox.Controls.Add(this.mcuLabel);
             this.fileGroupBox.Controls.Add(this.mcuBox);
-            this.fileGroupBox.Location = new System.Drawing.Point(12, 12);
+            this.fileGroupBox.Location = new System.Drawing.Point(12, 32);
             this.fileGroupBox.Name = "fileGroupBox";
             this.fileGroupBox.Size = new System.Drawing.Size(776, 48);
             this.fileGroupBox.TabIndex = 25;
             this.fileGroupBox.TabStop = false;
             this.fileGroupBox.Text = "Local file";
-            // 
-            // filepathBox
-            // 
-            this.filepathBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.filepathBox.FormattingEnabled = true;
-            this.filepathBox.Location = new System.Drawing.Point(6, 19);
-            this.filepathBox.Name = "filepathBox";
-            this.filepathBox.Size = new System.Drawing.Size(558, 21);
-            this.filepathBox.TabIndex = 2;
-            this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
-            this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.filepathBox_KeyDown);
             // 
             // mcuBox
             // 
@@ -242,7 +230,7 @@ namespace QMK_Toolbox {
             // 
             this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.clearEepromButton.Enabled = false;
-            this.clearEepromButton.Location = new System.Drawing.Point(12, 606);
+            this.clearEepromButton.Location = new System.Drawing.Point(12, 630);
             this.clearEepromButton.Name = "clearEepromButton";
             this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
             this.clearEepromButton.TabIndex = 27;
@@ -263,10 +251,10 @@ namespace QMK_Toolbox {
             this.logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.logTextBox.ForeColor = System.Drawing.Color.White;
             this.logTextBox.HideSelection = false;
-            this.logTextBox.Location = new System.Drawing.Point(12, 120);
+            this.logTextBox.Location = new System.Drawing.Point(12, 140);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(776, 480);
+            this.logTextBox.Size = new System.Drawing.Size(776, 484);
             this.logTextBox.TabIndex = 1;
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
@@ -344,106 +332,135 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hidList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.hidList.FormattingEnabled = true;
-            this.hidList.Location = new System.Drawing.Point(128, 607);
+            this.hidList.Location = new System.Drawing.Point(128, 631);
             this.hidList.Name = "hidList";
             this.hidList.Size = new System.Drawing.Size(660, 21);
             this.hidList.TabIndex = 29;
             // 
             // mainMenu
             // 
-            this.mainMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.fileMenuItem,
-            this.toolsMenuItem,
-            this.helpMenuItem});
+            this.mainMenu.BackColor = System.Drawing.Color.Transparent;
+            this.mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem,
+            this.toolsToolStripMenuItem,
+            this.helpToolStripMenuItem});
+            this.mainMenu.Location = new System.Drawing.Point(0, 0);
+            this.mainMenu.Name = "mainMenu";
+            this.mainMenu.Size = new System.Drawing.Size(800, 24);
+            this.mainMenu.TabIndex = 30;
+            this.mainMenu.Text = "mainMenu";
             // 
-            // fileMenuItem
+            // fileToolStripMenuItem
             // 
-            this.fileMenuItem.Index = 0;
-            this.fileMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.openMenuItem,
-            this.fileMenuSep,
-            this.exitMenuItem});
-            this.fileMenuItem.Text = "&File";
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.openToolStripMenuItem,
+            this.fileToolStripMenuSep,
+            this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "&File";
             // 
-            // openMenuItem
+            // openToolStripMenuItem
             // 
-            this.openMenuItem.Index = 0;
-            this.openMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlO;
-            this.openMenuItem.Text = "&Open...";
-            this.openMenuItem.Click += new System.EventHandler(this.openFileButton_Click);
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.openToolStripMenuItem.Text = "&Open...";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.openFileButton_Click);
             // 
-            // fileMenuSep
+            // fileToolStripMenuSep
             // 
-            this.fileMenuSep.Index = 1;
-            this.fileMenuSep.Text = "-";
+            this.fileToolStripMenuSep.Name = "fileToolStripMenuSep";
+            this.fileToolStripMenuSep.Size = new System.Drawing.Size(177, 6);
             // 
-            // exitMenuItem
+            // exitToolStripMenuItem
             // 
-            this.exitMenuItem.Index = 2;
-            this.exitMenuItem.Shortcut = System.Windows.Forms.Shortcut.AltF4;
-            this.exitMenuItem.Text = "E&xit";
-            this.exitMenuItem.Click += new System.EventHandler(this.exitMenuItem_Click);
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exitToolStripMenuItem.Text = "E&xit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitMenuItem_Click);
             // 
-            // toolsMenuItem
+            // toolsToolStripMenuItem
             // 
-            this.toolsMenuItem.Index = 1;
-            this.toolsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.installDriversMenuItem,
-            this.toolsMenuSep,
-            this.optionsMenuItem});
-            this.toolsMenuItem.Text = "&Tools";
+            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.installDriversToolStripMenuItem,
+            this.toolsToolStripMenuSep,
+            this.optionsToolStripMenuItem});
+            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            this.toolsToolStripMenuItem.Text = "&Tools";
             // 
-            // installDriversMenuItem
+            // installDriversToolStripMenuItem
             // 
-            this.installDriversMenuItem.Index = 0;
-            this.installDriversMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlN;
-            this.installDriversMenuItem.Text = "I&nstall Drivers...";
-            this.installDriversMenuItem.Click += new System.EventHandler(this.installDriversMenuItem_Click);
+            this.installDriversToolStripMenuItem.Name = "installDriversToolStripMenuItem";
+            this.installDriversToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+            this.installDriversToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.installDriversToolStripMenuItem.Text = "I&nstall Drivers...";
+            this.installDriversToolStripMenuItem.Click += new System.EventHandler(this.installDriversMenuItem_Click);
             // 
-            // toolsMenuSep
+            // toolsToolStripMenuSep
             // 
-            this.toolsMenuSep.Index = 1;
-            this.toolsMenuSep.Text = "-";
+            this.toolsToolStripMenuSep.Name = "toolsToolStripMenuSep";
+            this.toolsToolStripMenuSep.Size = new System.Drawing.Size(193, 6);
             // 
-            // optionsMenuItem
+            // optionsToolStripMenuItem
             // 
-            this.optionsMenuItem.Enabled = false;
-            this.optionsMenuItem.Index = 2;
-            this.optionsMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlP;
-            this.optionsMenuItem.Text = "O&ptions...";
+            this.optionsToolStripMenuItem.Enabled = false;
+            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+            this.optionsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.optionsToolStripMenuItem.Text = "O&ptions...";
             // 
-            // helpMenuItem
+            // helpToolStripMenuItem
             // 
-            this.helpMenuItem.Index = 2;
-            this.helpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.checkForUpdatesMenuItem,
-            this.helpMenuSep,
-            this.aboutMenuItem});
-            this.helpMenuItem.Text = "&Help";
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.checkForUpdatesToolStripMenuItem,
+            this.helpToolStripMenuSep,
+            this.aboutToolStripMenuItem});
+            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Text = "&Help";
             // 
-            // checkForUpdatesMenuItem
+            // checkForUpdatesToolStripMenuItem
             // 
-            this.checkForUpdatesMenuItem.Enabled = false;
-            this.checkForUpdatesMenuItem.Index = 0;
-            this.checkForUpdatesMenuItem.Text = "Check for Updates...";
+            this.checkForUpdatesToolStripMenuItem.Enabled = false;
+            this.checkForUpdatesToolStripMenuItem.Name = "checkForUpdatesToolStripMenuItem";
+            this.checkForUpdatesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.checkForUpdatesToolStripMenuItem.Text = "Check for Updates...";
             // 
-            // helpMenuSep
+            // helpToolStripMenuSep
             // 
-            this.helpMenuSep.Index = 1;
-            this.helpMenuSep.Text = "-";
+            this.helpToolStripMenuSep.Name = "helpToolStripMenuSep";
+            this.helpToolStripMenuSep.Size = new System.Drawing.Size(177, 6);
             // 
-            // aboutMenuItem
+            // aboutToolStripMenuItem
             // 
-            this.aboutMenuItem.Index = 2;
-            this.aboutMenuItem.Text = "&About";
-            this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Text = "&About";
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
+            // 
+            // filepathBox
+            // 
+            this.filepathBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.filepathBox.FormattingEnabled = true;
+            this.filepathBox.Location = new System.Drawing.Point(6, 19);
+            this.filepathBox.Name = "filepathBox";
+            this.filepathBox.Size = new System.Drawing.Size(558, 21);
+            this.filepathBox.TabIndex = 2;
+            this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
+            this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.filepathBox_KeyDown);
             // 
             // MainWindow
             // 
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 640);
+            this.ClientSize = new System.Drawing.Size(800, 664);
+            this.Controls.Add(this.mainMenu);
             this.Controls.Add(this.hidList);
             this.Controls.Add(this.clearEepromButton);
             this.Controls.Add(this.fileGroupBox);
@@ -453,8 +470,8 @@ namespace QMK_Toolbox {
             this.Controls.Add(this.logTextBox);
             this.Controls.Add(this.resetButton);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Menu = this.mainMenu;
-            this.MinimumSize = new System.Drawing.Size(816, 699);
+            this.MainMenuStrip = this.mainMenu;
+            this.MinimumSize = new System.Drawing.Size(816, 703);
             this.Name = "MainWindow";
             this.Text = "QMK Toolbox";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainWindow_FormClosing);
@@ -468,6 +485,8 @@ namespace QMK_Toolbox {
             this.fileGroupBox.ResumeLayout(false);
             this.fileGroupBox.PerformLayout();
             this.logContextMenu.ResumeLayout(false);
+            this.mainMenu.ResumeLayout(false);
+            this.mainMenu.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -499,19 +518,19 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator logContextMenuSep2;
-        private System.Windows.Forms.MainMenu mainMenu;
-        private System.Windows.Forms.MenuItem fileMenuItem;
-        private System.Windows.Forms.MenuItem openMenuItem;
-        private System.Windows.Forms.MenuItem fileMenuSep;
-        private System.Windows.Forms.MenuItem exitMenuItem;
-        private System.Windows.Forms.MenuItem toolsMenuItem;
-        private System.Windows.Forms.MenuItem installDriversMenuItem;
-        private System.Windows.Forms.MenuItem helpMenuItem;
-        private System.Windows.Forms.MenuItem aboutMenuItem;
-        private System.Windows.Forms.MenuItem toolsMenuSep;
-        private System.Windows.Forms.MenuItem optionsMenuItem;
-        private System.Windows.Forms.MenuItem checkForUpdatesMenuItem;
-        private System.Windows.Forms.MenuItem helpMenuSep;
+        private System.Windows.Forms.MenuStrip mainMenu;
+        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator fileToolStripMenuSep;
+        private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toolsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem installDriversToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolsToolStripMenuSep;
+        private System.Windows.Forms.ToolStripMenuItem optionsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem checkForUpdatesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator helpToolStripMenuSep;
     }
 }
 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -59,7 +59,7 @@ namespace QMK_Toolbox {
             this.installDriversMenuItem = new System.Windows.Forms.MenuItem();
             this.toolsMenuSep = new System.Windows.Forms.MenuItem();
             this.optionsMenuItem = new System.Windows.Forms.MenuItem();
-            this.HelpMenuItem = new System.Windows.Forms.MenuItem();
+            this.helpMenuItem = new System.Windows.Forms.MenuItem();
             this.checkForUpdatesMenuItem = new System.Windows.Forms.MenuItem();
             this.helpMenuSep = new System.Windows.Forms.MenuItem();
             this.aboutMenuItem = new System.Windows.Forms.MenuItem();
@@ -355,7 +355,7 @@ namespace QMK_Toolbox {
             this.mainMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.fileMenuItem,
             this.toolsMenuItem,
-            this.HelpMenuItem});
+            this.helpMenuItem});
             // 
             // fileMenuItem
             // 
@@ -413,14 +413,14 @@ namespace QMK_Toolbox {
             this.optionsMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlP;
             this.optionsMenuItem.Text = "O&ptions...";
             // 
-            // HelpMenuItem
+            // helpMenuItem
             // 
-            this.HelpMenuItem.Index = 2;
-            this.HelpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.helpMenuItem.Index = 2;
+            this.helpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.checkForUpdatesMenuItem,
             this.helpMenuSep,
             this.aboutMenuItem});
-            this.HelpMenuItem.Text = "&Help";
+            this.helpMenuItem.Text = "&Help";
             // 
             // checkForUpdatesMenuItem
             // 
@@ -507,7 +507,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.MenuItem exitMenuItem;
         private System.Windows.Forms.MenuItem toolsMenuItem;
         private System.Windows.Forms.MenuItem installDriversMenuItem;
-        private System.Windows.Forms.MenuItem HelpMenuItem;
+        private System.Windows.Forms.MenuItem helpMenuItem;
         private System.Windows.Forms.MenuItem aboutMenuItem;
         private System.Windows.Forms.MenuItem toolsMenuSep;
         private System.Windows.Forms.MenuItem optionsMenuItem;

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -271,7 +271,6 @@ namespace QMK_Toolbox {
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
             this.logTextBox.ZoomFactor = global::QMK_Toolbox.Properties.Settings.Default.outputZoom;
-            this.logTextBox.TextChanged += new System.EventHandler(this.logTextBox_TextChanged);
             // 
             // logContextMenu
             // 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -60,9 +60,9 @@ namespace QMK_Toolbox {
             this.toolsMenuSep = new System.Windows.Forms.MenuItem();
             this.optionsMenuItem = new System.Windows.Forms.MenuItem();
             this.HelpMenuItem = new System.Windows.Forms.MenuItem();
-            this.aboutMenuItem = new System.Windows.Forms.MenuItem();
             this.checkForUpdatesMenuItem = new System.Windows.Forms.MenuItem();
             this.helpMenuSep = new System.Windows.Forms.MenuItem();
+            this.aboutMenuItem = new System.Windows.Forms.MenuItem();
             this.qmkfmGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
             this.logContextMenu.SuspendLayout();
@@ -422,12 +422,6 @@ namespace QMK_Toolbox {
             this.aboutMenuItem});
             this.HelpMenuItem.Text = "&Help";
             // 
-            // aboutMenuItem
-            // 
-            this.aboutMenuItem.Index = 2;
-            this.aboutMenuItem.Text = "&About";
-            this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
-            // 
             // checkForUpdatesMenuItem
             // 
             this.checkForUpdatesMenuItem.Enabled = false;
@@ -438,6 +432,12 @@ namespace QMK_Toolbox {
             // 
             this.helpMenuSep.Index = 1;
             this.helpMenuSep.Text = "-";
+            // 
+            // aboutMenuItem
+            // 
+            this.aboutMenuItem.Index = 2;
+            this.aboutMenuItem.Text = "&About";
+            this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
             // 
             // MainWindow
             // 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -72,7 +72,7 @@ namespace QMK_Toolbox {
             // 
             this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.flashButton.Enabled = false;
-            this.flashButton.Location = new System.Drawing.Point(652, 66);
+            this.flashButton.Location = new System.Drawing.Point(653, 66);
             this.flashButton.Name = "flashButton";
             this.flashButton.Size = new System.Drawing.Size(62, 23);
             this.flashButton.TabIndex = 6;
@@ -84,7 +84,7 @@ namespace QMK_Toolbox {
             this.autoflashCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.autoflashCheckbox.AutoSize = true;
             this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.autoflashCheckbox.Location = new System.Drawing.Point(652, 95);
+            this.autoflashCheckbox.Location = new System.Drawing.Point(653, 95);
             this.autoflashCheckbox.Name = "autoflashCheckbox";
             this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
             this.autoflashCheckbox.TabIndex = 5;
@@ -100,7 +100,7 @@ namespace QMK_Toolbox {
             // openFileButton
             // 
             this.openFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.openFileButton.Location = new System.Drawing.Point(570, 18);
+            this.openFileButton.Location = new System.Drawing.Point(571, 18);
             this.openFileButton.Name = "openFileButton";
             this.openFileButton.Size = new System.Drawing.Size(64, 23);
             this.openFileButton.TabIndex = 3;
@@ -112,7 +112,7 @@ namespace QMK_Toolbox {
             // 
             this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.resetButton.Enabled = false;
-            this.resetButton.Location = new System.Drawing.Point(720, 66);
+            this.resetButton.Location = new System.Drawing.Point(721, 66);
             this.resetButton.Name = "resetButton";
             this.resetButton.Size = new System.Drawing.Size(67, 23);
             this.resetButton.TabIndex = 7;
@@ -123,7 +123,7 @@ namespace QMK_Toolbox {
             // 
             this.mcuLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.mcuLabel.AutoSize = true;
-            this.mcuLabel.Location = new System.Drawing.Point(637, 0);
+            this.mcuLabel.Location = new System.Drawing.Point(638, 0);
             this.mcuLabel.Name = "mcuLabel";
             this.mcuLabel.Size = new System.Drawing.Size(84, 13);
             this.mcuLabel.TabIndex = 22;
@@ -139,7 +139,7 @@ namespace QMK_Toolbox {
             this.qmkfmGroupBox.Controls.Add(this.loadKeymap);
             this.qmkfmGroupBox.Location = new System.Drawing.Point(12, 66);
             this.qmkfmGroupBox.Name = "qmkfmGroupBox";
-            this.qmkfmGroupBox.Size = new System.Drawing.Size(634, 48);
+            this.qmkfmGroupBox.Size = new System.Drawing.Size(635, 48);
             this.qmkfmGroupBox.TabIndex = 23;
             this.qmkfmGroupBox.TabStop = false;
             this.qmkfmGroupBox.Text = "Keyboard from qmk.fm";
@@ -148,7 +148,7 @@ namespace QMK_Toolbox {
             // 
             this.keymapLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.keymapLabel.AutoSize = true;
-            this.keymapLabel.Location = new System.Drawing.Point(446, 0);
+            this.keymapLabel.Location = new System.Drawing.Point(447, 0);
             this.keymapLabel.Name = "keymapLabel";
             this.keymapLabel.Size = new System.Drawing.Size(45, 13);
             this.keymapLabel.TabIndex = 24;
@@ -162,7 +162,7 @@ namespace QMK_Toolbox {
             this.keymapBox.FormattingEnabled = true;
             this.keymapBox.Items.AddRange(new object[] {
             "later version!"});
-            this.keymapBox.Location = new System.Drawing.Point(449, 19);
+            this.keymapBox.Location = new System.Drawing.Point(450, 19);
             this.keymapBox.Name = "keymapBox";
             this.keymapBox.Size = new System.Drawing.Size(109, 21);
             this.keymapBox.TabIndex = 4;
@@ -181,7 +181,7 @@ namespace QMK_Toolbox {
             "this feature coming in"});
             this.keyboardBox.Location = new System.Drawing.Point(6, 19);
             this.keyboardBox.Name = "keyboardBox";
-            this.keyboardBox.Size = new System.Drawing.Size(437, 21);
+            this.keyboardBox.Size = new System.Drawing.Size(438, 21);
             this.keyboardBox.TabIndex = 4;
             this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
             this.keyboardBox.TextChanged += new System.EventHandler(this.keyboardBox_TextChanged);
@@ -190,7 +190,7 @@ namespace QMK_Toolbox {
             // 
             this.loadKeymap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.loadKeymap.Enabled = false;
-            this.loadKeymap.Location = new System.Drawing.Point(564, 18);
+            this.loadKeymap.Location = new System.Drawing.Point(565, 18);
             this.loadKeymap.Name = "loadKeymap";
             this.loadKeymap.Size = new System.Drawing.Size(64, 23);
             this.loadKeymap.TabIndex = 3;
@@ -208,7 +208,7 @@ namespace QMK_Toolbox {
             this.fileGroupBox.Controls.Add(this.mcuBox);
             this.fileGroupBox.Location = new System.Drawing.Point(12, 12);
             this.fileGroupBox.Name = "fileGroupBox";
-            this.fileGroupBox.Size = new System.Drawing.Size(775, 48);
+            this.fileGroupBox.Size = new System.Drawing.Size(776, 48);
             this.fileGroupBox.TabIndex = 25;
             this.fileGroupBox.TabStop = false;
             this.fileGroupBox.Text = "Local file";
@@ -221,7 +221,7 @@ namespace QMK_Toolbox {
             this.filepathBox.FormattingEnabled = true;
             this.filepathBox.Location = new System.Drawing.Point(6, 19);
             this.filepathBox.Name = "filepathBox";
-            this.filepathBox.Size = new System.Drawing.Size(557, 21);
+            this.filepathBox.Size = new System.Drawing.Size(558, 21);
             this.filepathBox.TabIndex = 2;
             this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
             this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.filepathBox_KeyDown);
@@ -232,7 +232,7 @@ namespace QMK_Toolbox {
             this.mcuBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "targetSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.mcuBox.FormattingEnabled = true;
-            this.mcuBox.Location = new System.Drawing.Point(640, 19);
+            this.mcuBox.Location = new System.Drawing.Point(641, 19);
             this.mcuBox.Name = "mcuBox";
             this.mcuBox.Size = new System.Drawing.Size(129, 21);
             this.mcuBox.TabIndex = 4;
@@ -242,7 +242,7 @@ namespace QMK_Toolbox {
             // 
             this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.clearEepromButton.Enabled = false;
-            this.clearEepromButton.Location = new System.Drawing.Point(12, 607);
+            this.clearEepromButton.Location = new System.Drawing.Point(12, 606);
             this.clearEepromButton.Name = "clearEepromButton";
             this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
             this.clearEepromButton.TabIndex = 27;
@@ -266,7 +266,7 @@ namespace QMK_Toolbox {
             this.logTextBox.Location = new System.Drawing.Point(12, 120);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(775, 481);
+            this.logTextBox.Size = new System.Drawing.Size(776, 480);
             this.logTextBox.TabIndex = 1;
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
@@ -345,9 +345,9 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hidList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.hidList.FormattingEnabled = true;
-            this.hidList.Location = new System.Drawing.Point(128, 608);
+            this.hidList.Location = new System.Drawing.Point(128, 607);
             this.hidList.Name = "hidList";
-            this.hidList.Size = new System.Drawing.Size(659, 21);
+            this.hidList.Size = new System.Drawing.Size(660, 21);
             this.hidList.TabIndex = 29;
             // 
             // mainMenu
@@ -444,7 +444,7 @@ namespace QMK_Toolbox {
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(799, 641);
+            this.ClientSize = new System.Drawing.Size(800, 640);
             this.Controls.Add(this.hidList);
             this.Controls.Add(this.clearEepromButton);
             this.Controls.Add(this.fileGroupBox);
@@ -455,7 +455,7 @@ namespace QMK_Toolbox {
             this.Controls.Add(this.resetButton);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Menu = this.mainMenu;
-            this.MinimumSize = new System.Drawing.Size(815, 700);
+            this.MinimumSize = new System.Drawing.Size(816, 699);
             this.Name = "MainWindow";
             this.Text = "QMK Toolbox";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainWindow_FormClosing);

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -264,7 +264,7 @@ namespace QMK_Toolbox {
             this.logTextBox.Location = new System.Drawing.Point(12, 120);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(775, 482);
+            this.logTextBox.Size = new System.Drawing.Size(775, 481);
             this.logTextBox.TabIndex = 1;
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
@@ -343,9 +343,9 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hidList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.hidList.FormattingEnabled = true;
-            this.hidList.Location = new System.Drawing.Point(129, 608);
+            this.hidList.Location = new System.Drawing.Point(128, 608);
             this.hidList.Name = "hidList";
-            this.hidList.Size = new System.Drawing.Size(658, 21);
+            this.hidList.Size = new System.Drawing.Size(659, 21);
             this.hidList.TabIndex = 29;
             // 
             // mainMenu

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -45,9 +45,9 @@ namespace QMK_Toolbox {
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.logContextMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
             this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
             this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
             this.mainMenu = new System.Windows.Forms.MainMenu(this.components);
@@ -279,9 +279,9 @@ namespace QMK_Toolbox {
             this.cutToolStripMenuItem,
             this.copyToolStripMenuItem,
             this.pasteToolStripMenuItem,
-            this.toolStripMenuItem1,
+            this.logContextMenuSep1,
             this.selectAllToolStripMenuItem,
-            this.toolStripMenuItem2,
+            this.logContextMenuSep2,
             this.clearToolStripMenuItem});
             this.logContextMenu.Name = "contextMenuStrip2";
             this.logContextMenu.ShowImageMargin = false;
@@ -312,10 +312,10 @@ namespace QMK_Toolbox {
             this.pasteToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
             this.pasteToolStripMenuItem.Text = "Paste";
             // 
-            // toolStripMenuItem1
+            // logContextMenuSep1
             // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(136, 6);
+            this.logContextMenuSep1.Name = "logContextMenuSep1";
+            this.logContextMenuSep1.Size = new System.Drawing.Size(136, 6);
             // 
             // selectAllToolStripMenuItem
             // 
@@ -326,10 +326,10 @@ namespace QMK_Toolbox {
             this.selectAllToolStripMenuItem.Text = "Select &All";
             this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
             // 
-            // toolStripMenuItem2
+            // logContextMenuSep2
             // 
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(136, 6);
+            this.logContextMenuSep2.Name = "logContextMenuSep2";
+            this.logContextMenuSep2.Size = new System.Drawing.Size(136, 6);
             // 
             // clearToolStripMenuItem
             // 
@@ -494,12 +494,12 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.ContextMenuStrip logContextMenu;
         private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
         private BetterComboBox filepathBox;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripSeparator logContextMenuSep1;
         private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+        private System.Windows.Forms.ToolStripSeparator logContextMenuSep2;
         private System.Windows.Forms.MainMenu mainMenu;
         private System.Windows.Forms.MenuItem fileMenuItem;
         private System.Windows.Forms.MenuItem openMenuItem;

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -30,10 +30,8 @@ namespace QMK_Toolbox {
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.openFileButton = new System.Windows.Forms.Button();
             this.resetButton = new System.Windows.Forms.Button();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.toolStripStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.mcuLabel = new System.Windows.Forms.Label();
-            this.qmkGroupBox = new System.Windows.Forms.GroupBox();
+            this.qmkfmGroupBox = new System.Windows.Forms.GroupBox();
             this.keymapLabel = new System.Windows.Forms.Label();
             this.keymapBox = new System.Windows.Forms.ComboBox();
             this.keyboardBox = new System.Windows.Forms.ComboBox();
@@ -42,11 +40,8 @@ namespace QMK_Toolbox {
             this.filepathBox = new QMK_Toolbox.BetterComboBox();
             this.mcuBox = new System.Windows.Forms.ComboBox();
             this.clearEepromButton = new System.Windows.Forms.Button();
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.installDriversToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logTextBox = new System.Windows.Forms.RichTextBox();
-            this.contextMenuStrip2 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.logContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -55,42 +50,45 @@ namespace QMK_Toolbox {
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hidList = new System.Windows.Forms.ComboBox();
-            this.statusStrip.SuspendLayout();
-            this.qmkGroupBox.SuspendLayout();
+            this.mainMenu = new System.Windows.Forms.MainMenu(this.components);
+            this.fileMenuItem = new System.Windows.Forms.MenuItem();
+            this.openMenuItem = new System.Windows.Forms.MenuItem();
+            this.fileMenuSep = new System.Windows.Forms.MenuItem();
+            this.exitMenuItem = new System.Windows.Forms.MenuItem();
+            this.toolsMenuItem = new System.Windows.Forms.MenuItem();
+            this.installDriversMenuItem = new System.Windows.Forms.MenuItem();
+            this.toolsMenuSep = new System.Windows.Forms.MenuItem();
+            this.optionsMenuItem = new System.Windows.Forms.MenuItem();
+            this.HelpMenuItem = new System.Windows.Forms.MenuItem();
+            this.aboutMenuItem = new System.Windows.Forms.MenuItem();
+            this.qmkfmGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
-            this.contextMenuStrip1.SuspendLayout();
-            this.contextMenuStrip2.SuspendLayout();
+            this.logContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // flashButton
             // 
             this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.flashButton.Enabled = false;
-            this.flashButton.Location = new System.Drawing.Point(657, 59);
+            this.flashButton.Location = new System.Drawing.Point(652, 66);
             this.flashButton.Name = "flashButton";
-            this.flashButton.Size = new System.Drawing.Size(57, 23);
+            this.flashButton.Size = new System.Drawing.Size(62, 23);
             this.flashButton.TabIndex = 6;
-            this.flashButton.Tag = "Erase, flash, and reset the MCU with the provided .hex file";
             this.flashButton.Text = "Flash";
             this.flashButton.Click += new System.EventHandler(this.flashButton_Click);
-            this.flashButton.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.flashButton.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // autoflashCheckbox
             // 
             this.autoflashCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.autoflashCheckbox.AutoSize = true;
             this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.autoflashCheckbox.Location = new System.Drawing.Point(657, 86);
+            this.autoflashCheckbox.Location = new System.Drawing.Point(652, 95);
             this.autoflashCheckbox.Name = "autoflashCheckbox";
             this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
             this.autoflashCheckbox.TabIndex = 5;
-            this.autoflashCheckbox.Tag = "Automatically flash when a device is detected in DFU mode";
             this.autoflashCheckbox.Text = "Auto-Flash";
             this.autoflashCheckbox.UseVisualStyleBackColor = false;
             this.autoflashCheckbox.CheckedChanged += new System.EventHandler(this.autoflashCheckbox_CheckedChanged);
-            this.autoflashCheckbox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.autoflashCheckbox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // openFileDialog
             // 
@@ -100,76 +98,55 @@ namespace QMK_Toolbox {
             // openFileButton
             // 
             this.openFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.openFileButton.Location = new System.Drawing.Point(581, 19);
+            this.openFileButton.Location = new System.Drawing.Point(570, 18);
             this.openFileButton.Name = "openFileButton";
             this.openFileButton.Size = new System.Drawing.Size(64, 23);
             this.openFileButton.TabIndex = 3;
-            this.openFileButton.Tag = "Select a file from explorer";
             this.openFileButton.Text = "Open";
             this.openFileButton.UseVisualStyleBackColor = true;
             this.openFileButton.Click += new System.EventHandler(this.openFileButton_Click);
-            this.openFileButton.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.openFileButton.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // resetButton
             // 
             this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.resetButton.Enabled = false;
-            this.resetButton.Location = new System.Drawing.Point(720, 59);
+            this.resetButton.Location = new System.Drawing.Point(720, 66);
             this.resetButton.Name = "resetButton";
             this.resetButton.Size = new System.Drawing.Size(67, 23);
             this.resetButton.TabIndex = 7;
-            this.resetButton.Tag = "Reset the MCU back into application mode";
             this.resetButton.Text = "Exit DFU";
             this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
-            this.resetButton.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.resetButton.MouseHover += new System.EventHandler(this.btn_MouseLeave);
-            // 
-            // statusStrip
-            // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripStatusLabel});
-            this.statusStrip.Location = new System.Drawing.Point(0, 639);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(799, 22);
-            this.statusStrip.TabIndex = 15;
-            this.statusStrip.Text = "statusStrip";
-            // 
-            // toolStripStatusLabel
-            // 
-            this.toolStripStatusLabel.Name = "toolStripStatusLabel";
-            this.toolStripStatusLabel.Size = new System.Drawing.Size(0, 17);
             // 
             // mcuLabel
             // 
             this.mcuLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.mcuLabel.AutoSize = true;
-            this.mcuLabel.Location = new System.Drawing.Point(648, 0);
+            this.mcuLabel.Location = new System.Drawing.Point(637, 0);
             this.mcuLabel.Name = "mcuLabel";
             this.mcuLabel.Size = new System.Drawing.Size(84, 13);
             this.mcuLabel.TabIndex = 22;
             this.mcuLabel.Text = "MCU (AVR only)";
             // 
-            // qmkGroupBox
+            // qmkfmGroupBox
             // 
-            this.qmkGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.qmkfmGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.qmkGroupBox.Controls.Add(this.keymapLabel);
-            this.qmkGroupBox.Controls.Add(this.keymapBox);
-            this.qmkGroupBox.Controls.Add(this.keyboardBox);
-            this.qmkGroupBox.Controls.Add(this.loadKeymap);
-            this.qmkGroupBox.Location = new System.Drawing.Point(6, 59);
-            this.qmkGroupBox.Name = "qmkGroupBox";
-            this.qmkGroupBox.Size = new System.Drawing.Size(645, 48);
-            this.qmkGroupBox.TabIndex = 23;
-            this.qmkGroupBox.TabStop = false;
-            this.qmkGroupBox.Text = "Keyboard from qmk.fm";
+            this.qmkfmGroupBox.Controls.Add(this.keymapLabel);
+            this.qmkfmGroupBox.Controls.Add(this.keymapBox);
+            this.qmkfmGroupBox.Controls.Add(this.keyboardBox);
+            this.qmkfmGroupBox.Controls.Add(this.loadKeymap);
+            this.qmkfmGroupBox.Location = new System.Drawing.Point(12, 66);
+            this.qmkfmGroupBox.Name = "qmkfmGroupBox";
+            this.qmkfmGroupBox.Size = new System.Drawing.Size(634, 48);
+            this.qmkfmGroupBox.TabIndex = 23;
+            this.qmkfmGroupBox.TabStop = false;
+            this.qmkfmGroupBox.Text = "Keyboard from qmk.fm";
             // 
             // keymapLabel
             // 
             this.keymapLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.keymapLabel.AutoSize = true;
-            this.keymapLabel.Location = new System.Drawing.Point(457, 0);
+            this.keymapLabel.Location = new System.Drawing.Point(446, 0);
             this.keymapLabel.Name = "keymapLabel";
             this.keymapLabel.Size = new System.Drawing.Size(45, 13);
             this.keymapLabel.TabIndex = 24;
@@ -183,14 +160,11 @@ namespace QMK_Toolbox {
             this.keymapBox.FormattingEnabled = true;
             this.keymapBox.Items.AddRange(new object[] {
             "later version!"});
-            this.keymapBox.Location = new System.Drawing.Point(457, 20);
+            this.keymapBox.Location = new System.Drawing.Point(449, 19);
             this.keymapBox.Name = "keymapBox";
-            this.keymapBox.Size = new System.Drawing.Size(112, 21);
+            this.keymapBox.Size = new System.Drawing.Size(109, 21);
             this.keymapBox.TabIndex = 4;
-            this.keymapBox.Tag = "The target (MCU) of the flashing";
             this.keymapBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keymap;
-            this.keymapBox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.keymapBox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // keyboardBox
             // 
@@ -203,30 +177,24 @@ namespace QMK_Toolbox {
             this.keyboardBox.FormattingEnabled = true;
             this.keyboardBox.Items.AddRange(new object[] {
             "this feature coming in"});
-            this.keyboardBox.Location = new System.Drawing.Point(6, 20);
+            this.keyboardBox.Location = new System.Drawing.Point(6, 19);
             this.keyboardBox.Name = "keyboardBox";
-            this.keyboardBox.Size = new System.Drawing.Size(445, 21);
+            this.keyboardBox.Size = new System.Drawing.Size(437, 21);
             this.keyboardBox.TabIndex = 4;
-            this.keyboardBox.Tag = "The target (MCU) of the flashing";
             this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
-            this.keyboardBox.TextChanged += new System.EventHandler(this.KeyboardBox_TextChanged);
-            this.keyboardBox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.keyboardBox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
+            this.keyboardBox.TextChanged += new System.EventHandler(this.keyboardBox_TextChanged);
             // 
             // loadKeymap
             // 
             this.loadKeymap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.loadKeymap.Enabled = false;
-            this.loadKeymap.Location = new System.Drawing.Point(575, 19);
+            this.loadKeymap.Location = new System.Drawing.Point(564, 18);
             this.loadKeymap.Name = "loadKeymap";
             this.loadKeymap.Size = new System.Drawing.Size(64, 23);
             this.loadKeymap.TabIndex = 3;
-            this.loadKeymap.Tag = "Load firmware from qmk.fm for this keyboard and keymap";
             this.loadKeymap.Text = "Load";
             this.loadKeymap.UseVisualStyleBackColor = true;
             this.loadKeymap.Click += new System.EventHandler(this.loadKeymap_Click);
-            this.loadKeymap.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.loadKeymap.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // fileGroupBox
             // 
@@ -236,9 +204,9 @@ namespace QMK_Toolbox {
             this.fileGroupBox.Controls.Add(this.filepathBox);
             this.fileGroupBox.Controls.Add(this.mcuLabel);
             this.fileGroupBox.Controls.Add(this.mcuBox);
-            this.fileGroupBox.Location = new System.Drawing.Point(6, 5);
+            this.fileGroupBox.Location = new System.Drawing.Point(12, 12);
             this.fileGroupBox.Name = "fileGroupBox";
-            this.fileGroupBox.Size = new System.Drawing.Size(786, 48);
+            this.fileGroupBox.Size = new System.Drawing.Size(775, 48);
             this.fileGroupBox.TabIndex = 25;
             this.fileGroupBox.TabStop = false;
             this.fileGroupBox.Text = "Local file";
@@ -249,15 +217,12 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.filepathBox.FormattingEnabled = true;
-            this.filepathBox.Location = new System.Drawing.Point(6, 20);
+            this.filepathBox.Location = new System.Drawing.Point(6, 19);
             this.filepathBox.Name = "filepathBox";
-            this.filepathBox.Size = new System.Drawing.Size(569, 21);
+            this.filepathBox.Size = new System.Drawing.Size(557, 21);
             this.filepathBox.TabIndex = 2;
-            this.filepathBox.Tag = "The path for your firmware file";
             this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
             this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.filepathBox_KeyDown);
-            this.filepathBox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.filepathBox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // mcuBox
             // 
@@ -265,49 +230,23 @@ namespace QMK_Toolbox {
             this.mcuBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "targetSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.mcuBox.FormattingEnabled = true;
-            this.mcuBox.Location = new System.Drawing.Point(651, 20);
+            this.mcuBox.Location = new System.Drawing.Point(640, 19);
             this.mcuBox.Name = "mcuBox";
             this.mcuBox.Size = new System.Drawing.Size(129, 21);
             this.mcuBox.TabIndex = 4;
-            this.mcuBox.Tag = "The target (MCU) of the flashing";
             this.mcuBox.Text = global::QMK_Toolbox.Properties.Settings.Default.targetSetting;
-            this.mcuBox.MouseEnter += new System.EventHandler(this.btn_MouseEnter);
-            this.mcuBox.MouseHover += new System.EventHandler(this.btn_MouseLeave);
             // 
             // clearEepromButton
             // 
             this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.clearEepromButton.Enabled = false;
-            this.clearEepromButton.Location = new System.Drawing.Point(12, 613);
+            this.clearEepromButton.Location = new System.Drawing.Point(12, 607);
             this.clearEepromButton.Name = "clearEepromButton";
             this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
             this.clearEepromButton.TabIndex = 27;
             this.clearEepromButton.Text = "Clear EEPROM";
             this.clearEepromButton.UseVisualStyleBackColor = true;
             this.clearEepromButton.Click += new System.EventHandler(this.clearEepromButton_Click);
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.installDriversToolStripMenuItem,
-            this.aboutToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.ShowImageMargin = false;
-            this.contextMenuStrip1.Size = new System.Drawing.Size(129, 48);
-            // 
-            // installDriversToolStripMenuItem
-            // 
-            this.installDriversToolStripMenuItem.Name = "installDriversToolStripMenuItem";
-            this.installDriversToolStripMenuItem.Size = new System.Drawing.Size(128, 22);
-            this.installDriversToolStripMenuItem.Text = "Install Drivers...";
-            this.installDriversToolStripMenuItem.Click += new System.EventHandler(this.installDriversToolStripMenuItem_Click);
-            // 
-            // aboutToolStripMenuItem
-            // 
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(128, 22);
-            this.aboutToolStripMenuItem.Text = "About";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
             // logTextBox
             // 
@@ -316,25 +255,25 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.logTextBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
             this.logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.logTextBox.ContextMenuStrip = this.contextMenuStrip2;
+            this.logTextBox.ContextMenuStrip = this.logContextMenu;
             this.logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", global::QMK_Toolbox.Properties.Settings.Default, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.logTextBox.DetectUrls = false;
             this.logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.logTextBox.ForeColor = System.Drawing.Color.White;
             this.logTextBox.HideSelection = false;
-            this.logTextBox.Location = new System.Drawing.Point(12, 112);
+            this.logTextBox.Location = new System.Drawing.Point(12, 120);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(775, 495);
+            this.logTextBox.Size = new System.Drawing.Size(775, 482);
             this.logTextBox.TabIndex = 1;
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
             this.logTextBox.ZoomFactor = global::QMK_Toolbox.Properties.Settings.Default.outputZoom;
             this.logTextBox.TextChanged += new System.EventHandler(this.logTextBox_TextChanged);
             // 
-            // contextMenuStrip2
+            // logContextMenu
             // 
-            this.contextMenuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.logContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.cutToolStripMenuItem,
             this.copyToolStripMenuItem,
             this.pasteToolStripMenuItem,
@@ -342,10 +281,10 @@ namespace QMK_Toolbox {
             this.selectAllToolStripMenuItem,
             this.toolStripMenuItem2,
             this.clearToolStripMenuItem});
-            this.contextMenuStrip2.Name = "contextMenuStrip2";
-            this.contextMenuStrip2.ShowImageMargin = false;
-            this.contextMenuStrip2.Size = new System.Drawing.Size(140, 126);
-            this.contextMenuStrip2.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip2_Opening);
+            this.logContextMenu.Name = "contextMenuStrip2";
+            this.logContextMenu.ShowImageMargin = false;
+            this.logContextMenu.Size = new System.Drawing.Size(140, 126);
+            this.logContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip2_Opening);
             // 
             // cutToolStripMenuItem
             // 
@@ -404,28 +343,103 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hidList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.hidList.FormattingEnabled = true;
-            this.hidList.Location = new System.Drawing.Point(128, 615);
+            this.hidList.Location = new System.Drawing.Point(129, 608);
             this.hidList.Name = "hidList";
             this.hidList.Size = new System.Drawing.Size(658, 21);
             this.hidList.TabIndex = 29;
+            // 
+            // mainMenu
+            // 
+            this.mainMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.fileMenuItem,
+            this.toolsMenuItem,
+            this.HelpMenuItem});
+            // 
+            // fileMenuItem
+            // 
+            this.fileMenuItem.Index = 0;
+            this.fileMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.openMenuItem,
+            this.fileMenuSep,
+            this.exitMenuItem});
+            this.fileMenuItem.Text = "&File";
+            // 
+            // openMenuItem
+            // 
+            this.openMenuItem.Index = 0;
+            this.openMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlO;
+            this.openMenuItem.Text = "&Open...";
+            this.openMenuItem.Click += new System.EventHandler(this.openFileButton_Click);
+            // 
+            // fileMenuSep
+            // 
+            this.fileMenuSep.Index = 1;
+            this.fileMenuSep.Text = "-";
+            // 
+            // exitMenuItem
+            // 
+            this.exitMenuItem.Index = 2;
+            this.exitMenuItem.Shortcut = System.Windows.Forms.Shortcut.AltF4;
+            this.exitMenuItem.Text = "E&xit";
+            this.exitMenuItem.Click += new System.EventHandler(this.exitMenuItem_Click);
+            // 
+            // toolsMenuItem
+            // 
+            this.toolsMenuItem.Index = 1;
+            this.toolsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.installDriversMenuItem,
+            this.toolsMenuSep,
+            this.optionsMenuItem});
+            this.toolsMenuItem.Text = "&Tools";
+            // 
+            // installDriversMenuItem
+            // 
+            this.installDriversMenuItem.Index = 0;
+            this.installDriversMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlN;
+            this.installDriversMenuItem.Text = "I&nstall Drivers...";
+            this.installDriversMenuItem.Click += new System.EventHandler(this.installDriversMenuItem_Click);
+            // 
+            // toolsMenuSep
+            // 
+            this.toolsMenuSep.Index = 1;
+            this.toolsMenuSep.Text = "-";
+            // 
+            // optionsMenuItem
+            // 
+            this.optionsMenuItem.Enabled = false;
+            this.optionsMenuItem.Index = 2;
+            this.optionsMenuItem.Shortcut = System.Windows.Forms.Shortcut.CtrlP;
+            this.optionsMenuItem.Text = "O&ptions...";
+            // 
+            // HelpMenuItem
+            // 
+            this.HelpMenuItem.Index = 2;
+            this.HelpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.aboutMenuItem});
+            this.HelpMenuItem.Text = "&Help";
+            // 
+            // aboutMenuItem
+            // 
+            this.aboutMenuItem.Index = 0;
+            this.aboutMenuItem.Text = "&About";
+            this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
             // 
             // MainWindow
             // 
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(799, 661);
-            this.ContextMenuStrip = this.contextMenuStrip1;
+            this.ClientSize = new System.Drawing.Size(799, 641);
             this.Controls.Add(this.hidList);
             this.Controls.Add(this.clearEepromButton);
             this.Controls.Add(this.fileGroupBox);
-            this.Controls.Add(this.qmkGroupBox);
+            this.Controls.Add(this.qmkfmGroupBox);
             this.Controls.Add(this.flashButton);
             this.Controls.Add(this.autoflashCheckbox);
-            this.Controls.Add(this.statusStrip);
             this.Controls.Add(this.logTextBox);
             this.Controls.Add(this.resetButton);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Menu = this.mainMenu;
             this.MinimumSize = new System.Drawing.Size(815, 700);
             this.Name = "MainWindow";
             this.Text = "QMK Toolbox";
@@ -435,14 +449,11 @@ namespace QMK_Toolbox {
             this.Shown += new System.EventHandler(this.MainWindow_Shown);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.MainWindow_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.MainWindow_DragEnter);
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.qmkGroupBox.ResumeLayout(false);
-            this.qmkGroupBox.PerformLayout();
+            this.qmkfmGroupBox.ResumeLayout(false);
+            this.qmkfmGroupBox.PerformLayout();
             this.fileGroupBox.ResumeLayout(false);
             this.fileGroupBox.PerformLayout();
-            this.contextMenuStrip1.ResumeLayout(false);
-            this.contextMenuStrip2.ResumeLayout(false);
+            this.logContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -456,29 +467,35 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.RichTextBox logTextBox;
         private System.Windows.Forms.Button openFileButton;
         private System.Windows.Forms.Button resetButton;
-        private System.Windows.Forms.StatusStrip statusStrip;
-        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel;
         private System.Windows.Forms.Label mcuLabel;
-        private System.Windows.Forms.GroupBox qmkGroupBox;
+        private System.Windows.Forms.GroupBox qmkfmGroupBox;
         private System.Windows.Forms.ComboBox keymapBox;
         private System.Windows.Forms.ComboBox keyboardBox;
         private System.Windows.Forms.Button loadKeymap;
         private System.Windows.Forms.Label keymapLabel;
         private System.Windows.Forms.GroupBox fileGroupBox;
         private System.Windows.Forms.Button clearEepromButton;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ComboBox hidList;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
+        private System.Windows.Forms.ContextMenuStrip logContextMenu;
         private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
         private BetterComboBox filepathBox;
-        private System.Windows.Forms.ToolStripMenuItem installDriversToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+        private System.Windows.Forms.MainMenu mainMenu;
+        private System.Windows.Forms.MenuItem fileMenuItem;
+        private System.Windows.Forms.MenuItem openMenuItem;
+        private System.Windows.Forms.MenuItem fileMenuSep;
+        private System.Windows.Forms.MenuItem exitMenuItem;
+        private System.Windows.Forms.MenuItem toolsMenuItem;
+        private System.Windows.Forms.MenuItem installDriversMenuItem;
+        private System.Windows.Forms.MenuItem HelpMenuItem;
+        private System.Windows.Forms.MenuItem aboutMenuItem;
+        private System.Windows.Forms.MenuItem toolsMenuSep;
+        private System.Windows.Forms.MenuItem optionsMenuItem;
     }
 }
 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -61,6 +61,8 @@ namespace QMK_Toolbox {
             this.optionsMenuItem = new System.Windows.Forms.MenuItem();
             this.HelpMenuItem = new System.Windows.Forms.MenuItem();
             this.aboutMenuItem = new System.Windows.Forms.MenuItem();
+            this.checkForUpdatesMenuItem = new System.Windows.Forms.MenuItem();
+            this.helpMenuSep = new System.Windows.Forms.MenuItem();
             this.qmkfmGroupBox.SuspendLayout();
             this.fileGroupBox.SuspendLayout();
             this.logContextMenu.SuspendLayout();
@@ -415,14 +417,27 @@ namespace QMK_Toolbox {
             // 
             this.HelpMenuItem.Index = 2;
             this.HelpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.checkForUpdatesMenuItem,
+            this.helpMenuSep,
             this.aboutMenuItem});
             this.HelpMenuItem.Text = "&Help";
             // 
             // aboutMenuItem
             // 
-            this.aboutMenuItem.Index = 0;
+            this.aboutMenuItem.Index = 2;
             this.aboutMenuItem.Text = "&About";
             this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
+            // 
+            // checkForUpdatesMenuItem
+            // 
+            this.checkForUpdatesMenuItem.Enabled = false;
+            this.checkForUpdatesMenuItem.Index = 0;
+            this.checkForUpdatesMenuItem.Text = "Check for Updates...";
+            // 
+            // helpMenuSep
+            // 
+            this.helpMenuSep.Index = 1;
+            this.helpMenuSep.Text = "-";
             // 
             // MainWindow
             // 
@@ -496,6 +511,8 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.MenuItem aboutMenuItem;
         private System.Windows.Forms.MenuItem toolsMenuSep;
         private System.Windows.Forms.MenuItem optionsMenuItem;
+        private System.Windows.Forms.MenuItem checkForUpdatesMenuItem;
+        private System.Windows.Forms.MenuItem helpMenuSep;
     }
 }
 

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -36,21 +36,10 @@ namespace QMK_Toolbox
         private readonly Flashing _flasher;
         private readonly Usb _usb;
 
-        public const int MfSeparator = 0x800;
-        public const int WmSyscommand = 0x112;
-        public const int MfByposition = 0x400;
-        public const int About = 1000;
-
         private const int CB_SETCUEBANNER = 0x1703;
 
         [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         private static extern int SendMessage(IntPtr hWnd, int msg, int wParam, [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPWStr)]string lParam);
-
-        [DllImport("user32.dll")]
-        private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
-
-        [DllImport("user32.dll")]
-        private static extern bool InsertMenu(IntPtr hMenu, int wPosition, int wFlags, int wIdNewItem, string lpNewItem);
 
         public MainWindow()
         {
@@ -103,14 +92,6 @@ namespace QMK_Toolbox
                         SetFilePath(sr.ReadLine());
                     }
                     File.Delete(Path.Combine(Path.GetTempPath(), "qmk_toolbox_file.txt"));
-                }
-            }
-            if (m.Msg == WmSyscommand)
-            {
-                if (m.WParam.ToInt32() == About)
-                {
-                    (new AboutBox()).ShowDialog();
-                    return;
                 }
             }
 
@@ -175,12 +156,6 @@ namespace QMK_Toolbox
                 SecurityProtocolType.Tls |
                 SecurityProtocolType.Tls11 |
                 SecurityProtocolType.Tls12;
-
-            var menuHandle = GetSystemMenu(Handle, false);
-            InsertMenu(menuHandle, 0, MfByposition | MfSeparator, 0, string.Empty); // <-- Add a menu seperator
-            InsertMenu(menuHandle, 0, MfByposition, About, "About");
-
-            //_backgroundWorker.RunWorkerAsync();
 
             foreach (var mcu in _flasher.GetMcuList())
             {
@@ -649,20 +624,6 @@ namespace QMK_Toolbox
             clearEepromButton.Enabled = _flasher.CanClearEeprom();
         }
 
-        // Set the button's status tip.
-        private void btn_MouseEnter(object sender, EventArgs e)
-        {
-            if (sender is Control obj) toolStripStatusLabel.Text = obj.Tag.ToString();
-        }
-
-        // Remove the button's status tip.
-        private void btn_MouseLeave(object sender, EventArgs e)
-        {
-            //if (toolStripStatusLabel.Text.Equals((sender as Control).Tag)) {
-            //    toolStripStatusLabel.Text = "";
-            //}
-        }
-
         private void UpdateHidList()
         {
             if (!InvokeRequired)
@@ -731,17 +692,7 @@ namespace QMK_Toolbox
             }
         }
 
-        private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            (new AboutBox()).ShowDialog();
-        }
-
-        private void installDriversToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            InstallDrivers();
-        }
-
-        private void KeyboardBox_TextChanged(object sender, EventArgs e)
+        private void keyboardBox_TextChanged(object sender, EventArgs e)
         {
             loadKeymap.Enabled = keyboardBox.Items.Contains(keyboardBox.Text);
         }
@@ -765,6 +716,21 @@ namespace QMK_Toolbox
             copyToolStripMenuItem.Enabled = (logTextBox.SelectedText.Length > 0);
             selectAllToolStripMenuItem.Enabled = (logTextBox.Text.Length > 0);
             clearToolStripMenuItem.Enabled = (logTextBox.Text.Length > 0);
+        }
+
+        private void aboutMenuItem_Click(object sender, EventArgs e)
+        {
+            (new AboutBox()).ShowDialog();
+        }
+
+        private void exitMenuItem_Click(object sender, EventArgs e)
+        {
+            Application.Exit();
+        }
+
+        private void installDriversMenuItem_Click(object sender, EventArgs e)
+        {
+            InstallDrivers();
         }
     }
 }

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -133,15 +133,6 @@ namespace QMK_Toolbox
             StartListeningForDeviceEvents();
         }
 
-        private void logTextBox_TextChanged(object sender, EventArgs e)
-        {
-            // This shouldn't be needed anymore
-            // set the current caret position to the end
-            // logTextBox.SelectionStart = logTextBox.Text.Length;
-            // scroll it automatically
-            // logTextBox.ScrollToCaret();
-        }
-
         private void MainWindow_FormClosing(object sender, FormClosingEventArgs e)
         {
             var arraylist = new ArrayList(filepathBox.Items);

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -211,7 +211,7 @@ namespace QMK_Toolbox
                         keyboardBox.SelectedIndex = -1;
                         keyboardBox.ResetText();
                         keyboardBox.Enabled = true;
-                        loadKeymap.Enabled = false;
+                        loadKeymapButton.Enabled = false;
                         LoadKeymapList();
                     }
                 }
@@ -221,7 +221,7 @@ namespace QMK_Toolbox
                 _printer.PrintResponse("Something went wrong when trying to get the keyboard list from QMK.FM, you might not have a internet connection or the servers are down.", MessageType.Error);
                 keymapBox.Enabled = false;
                 keyboardBox.Enabled = false;
-                loadKeymap.Enabled = false;
+                loadKeymapButton.Enabled = false;
             }
         }
 
@@ -233,7 +233,7 @@ namespace QMK_Toolbox
             // keymapBox.Enabled = true;
         }
 
-        private void loadKeymap_Click(object sender, EventArgs e)
+        private void loadKeymapButton_Click(object sender, EventArgs e)
         {
             if (keyboardBox.Items.Count > 0)
             {
@@ -694,7 +694,7 @@ namespace QMK_Toolbox
 
         private void keyboardBox_TextChanged(object sender, EventArgs e)
         {
-            loadKeymap.Enabled = keyboardBox.Items.Contains(keyboardBox.Text);
+            loadKeymapButton.Enabled = keyboardBox.Items.Contains(keyboardBox.Text);
         }
 
         private void copyToolStripMenuItem_Click(object sender, EventArgs e)
@@ -711,7 +711,7 @@ namespace QMK_Toolbox
             logTextBox.Clear();
         }
 
-        private void contextMenuStrip2_Opening(object sender, CancelEventArgs e)
+        private void logContextMenuStrip_Opening(object sender, CancelEventArgs e)
         {
             copyToolStripMenuItem.Enabled = (logTextBox.SelectedText.Length > 0);
             selectAllToolStripMenuItem.Enabled = (logTextBox.Text.Length > 0);

--- a/windows/QMK Toolbox/MainWindow.resx
+++ b/windows/QMK Toolbox/MainWindow.resx
@@ -118,19 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
+  </metadata>
+  <metadata name="logContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>260, 17</value>
+  </metadata>
+  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>145, 17</value>
-  </metadata>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>257, 17</value>
-  </metadata>
-  <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>412, 17</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>47</value>
+    <value>48</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Added menu bar
- Removed status bar (now matches macOS; may reintroduce later if I find a good use for it)
- Cleaned up a bunch of control names

![image](https://user-images.githubusercontent.com/4781841/117102409-a0036a00-adbb-11eb-989b-e30db8ff8b59.png)
![image](https://user-images.githubusercontent.com/4781841/117102449-bb6e7500-adbb-11eb-8854-68052eddb9e1.png)
![image](https://user-images.githubusercontent.com/4781841/117102463-c32e1980-adbb-11eb-976b-3ac33b0c3a53.png)

To be filled out later:

- Recent files menu (revert BetterComboBox)
- Implement options dialog, where one can configure flashing tool locations & arguments etc.
- Keytester under Tools menu (#41)
- USB device log under Tools menu (all devices, not just Console-enabled and bootloaders)
- Move Console stuff into separate dialog to avoid confusion?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
