### PR TITLE
[Windows] Improve drag-drop events

### DIFF
--- a/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
+++ b/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
@@ -9,7 +9,7 @@ namespace QMK_Toolbox.Helpers
     {
         public static void ExtractResource(string file)
         {
-            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"QMK_Toolbox.{file}"))
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"QMK_Toolbox.Resources.{file}"))
             using (var filestream = new FileStream(Path.Combine(Application.LocalUserAppDataPath, file), FileMode.Create))
             {
                 stream?.CopyTo(filestream);

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -113,9 +113,8 @@ namespace QMK_Toolbox
         {
             if (path != string.Empty)
             {
-                if (Path.GetExtension(path)?.ToLower() == ".qmk" ||
-                    Path.GetExtension(path)?.ToLower() == ".hex" ||
-                    Path.GetExtension(path)?.ToLower() == ".bin")
+                var extension = Path.GetExtension(path)?.ToLower();
+                if (extension == ".qmk" || extension == ".hex" || extension == ".bin")
                 {
                     _filePassedIn = path;
                 }
@@ -660,7 +659,18 @@ namespace QMK_Toolbox
 
         private void MainWindow_DragEnter(object sender, DragEventArgs e)
         {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length == 1)
+                {
+                    var extension = Path.GetExtension(files.First())?.ToLower();
+                    if (extension == ".qmk" || extension == ".hex" || extension == ".bin")
+                    {
+                        e.Effect = DragDropEffects.Copy;
+                    }
+                }
+            }
         }
 
         private void MainWindow_Shown(object sender, EventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Make sure only single .hex, .bin and .qmk files get the drag-drop cursor. Also fix a problem from #270 where the resources weren't being extracted properly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
