### PR TITLE
[macOS] Fix deprecated pasteboard type

### DIFF
--- a/macos/QMK Toolbox/QMKWindow.m
+++ b/macos/QMK Toolbox/QMKWindow.m
@@ -11,20 +11,17 @@
 @implementation QMKWindow
 
 - (void)setup {
-    [self registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]];
+    [self registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
 };
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender {
     NSPasteboard *pboard = [sender draggingPasteboard];
 
-    if ([[pboard types] containsObject:NSFilenamesPboardType]) {
-        if ([[pboard pasteboardItems] count] == 1) {
-            NSString *file = [pboard propertyListForType:NSFilenamesPboardType][0];
-            NSString * fileExtension = [[file pathExtension] lowercaseString];
+    if ([[pboard pasteboardItems] count] == 1) {
+        NSString *fileExtension = [[NSURL URLFromPasteboard:pboard] pathExtension];
 
-            if ([fileExtension isEqualToString:@"qmk"] || [fileExtension isEqualToString:@"hex"] || [fileExtension isEqualToString:@"bin"]) {
-                return NSDragOperationCopy;
-            }
+        if ([fileExtension isEqualToString:@"qmk"] || [fileExtension isEqualToString:@"hex"] || [fileExtension isEqualToString:@"bin"]) {
+            return NSDragOperationCopy;
         }
     }
 
@@ -33,7 +30,7 @@
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
     NSPasteboard *pboard = [sender draggingPasteboard];
-    NSString *file = [pboard propertyListForType:NSFilenamesPboardType][0];
+    NSString *file = [[NSURL URLFromPasteboard:pboard] path];
     [(AppDelegate *)[[NSApplication sharedApplication] delegate] setFilePath:[NSURL fileURLWithPath:file]];
     return YES;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Turns out `NSFilenamesPboardType` is deprecated in favour of `NSPasteboardTypeFileURL`. I also removed the `containsObject` check as it seems the `registerForDraggedTypes` basically handles that.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
