### PR TITLE
[Windows] Subclass ComboBox for placeholder text

### DIFF
--- a/windows/QMK Toolbox/BetterComboBox.cs
+++ b/windows/QMK Toolbox/BetterComboBox.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace QMK_Toolbox
 {
-    public class BetterComboBox : ComboBox
+    public class BetterComboBox : ComboBoxPlaceholder
     {
         public override string Text
         {

--- a/windows/QMK Toolbox/ComboBoxPlaceholder.cs
+++ b/windows/QMK Toolbox/ComboBoxPlaceholder.cs
@@ -13,7 +13,7 @@ namespace QMK_Toolbox
 {
     public class ComboBoxPlaceholder : ComboBox
     {
-        private const int CB_SETCUEBANNER = 0x1703;
+        private const uint CB_SETCUEBANNER = 0x1703;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
         private static extern IntPtr SendMessage(HandleRef hWnd, uint msg, IntPtr wParam, String lParam);

--- a/windows/QMK Toolbox/ComboBoxPlaceholder.cs
+++ b/windows/QMK Toolbox/ComboBoxPlaceholder.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace QMK_Toolbox
+{
+    public class ComboBoxPlaceholder : ComboBox
+    {
+        private const int CB_SETCUEBANNER = 0x1703;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+        private static extern IntPtr SendMessage(HandleRef hWnd, uint msg, IntPtr wParam, String lParam);
+
+        private string _placeholderText = String.Empty;
+
+        /// <summary>
+        /// Gets or sets the text the <see cref="ComboBox"/> will display as a cue to the user.
+        /// </summary>
+        [Description("The text value to be displayed as a cue to the user.")]
+        [Category("Appearance")]
+        [DefaultValue("")]
+        [Localizable(true)]
+        public string PlaceholderText
+        {
+            get { return _placeholderText; }
+            set
+            {
+                if (value == null)
+                {
+                    value = String.Empty;
+                }
+
+                if (!_placeholderText.Equals(value, StringComparison.CurrentCulture))
+                {
+                    _placeholderText = value;
+                    UpdatePlaceholderText();
+                    OnPlaceholderTextChanged(EventArgs.Empty);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Occurs when the <see cref="PlaceholderText"/> property value changes.
+        /// </summary>
+        public event EventHandler PlaceholderTextChanged;
+
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        protected virtual void OnPlaceholderTextChanged(EventArgs e)
+        {
+            EventHandler handler = PlaceholderTextChanged;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            UpdatePlaceholderText();
+            base.OnHandleCreated(e);
+        }
+
+        private void UpdatePlaceholderText()
+        {
+            if (this.IsHandleCreated)
+            {
+                SendMessage(new HandleRef(this, this.Handle), CB_SETCUEBANNER, IntPtr.Zero, _placeholderText);
+            }
+        }
+    }
+}

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -34,7 +34,7 @@ namespace QMK_Toolbox {
             this.qmkfmGroupBox = new System.Windows.Forms.GroupBox();
             this.keymapLabel = new System.Windows.Forms.Label();
             this.keymapBox = new System.Windows.Forms.ComboBox();
-            this.keyboardBox = new System.Windows.Forms.ComboBox();
+            this.keyboardBox = new QMK_Toolbox.ComboBoxPlaceholder();
             this.loadKeymapButton = new System.Windows.Forms.Button();
             this.fileGroupBox = new System.Windows.Forms.GroupBox();
             this.mcuBox = new System.Windows.Forms.ComboBox();
@@ -168,24 +168,6 @@ namespace QMK_Toolbox {
             this.keymapBox.Size = new System.Drawing.Size(109, 21);
             this.keymapBox.TabIndex = 2;
             this.keymapBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keymap;
-            // 
-            // keyboardBox
-            // 
-            this.keyboardBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.keyboardBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.keyboardBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.keyboardBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "keyboard", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.keyboardBox.Enabled = false;
-            this.keyboardBox.FormattingEnabled = true;
-            this.keyboardBox.Items.AddRange(new object[] {
-            "this feature coming in"});
-            this.keyboardBox.Location = new System.Drawing.Point(6, 19);
-            this.keyboardBox.Name = "keyboardBox";
-            this.keyboardBox.Size = new System.Drawing.Size(438, 21);
-            this.keyboardBox.TabIndex = 0;
-            this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
-            this.keyboardBox.TextChanged += new System.EventHandler(this.keyboardBox_TextChanged);
             // 
             // loadKeymapButton
             // 
@@ -449,10 +431,30 @@ namespace QMK_Toolbox {
             this.filepathBox.FormattingEnabled = true;
             this.filepathBox.Location = new System.Drawing.Point(6, 19);
             this.filepathBox.Name = "filepathBox";
+            this.filepathBox.PlaceholderText = "Click Open or drag to window to select file";
             this.filepathBox.Size = new System.Drawing.Size(558, 21);
             this.filepathBox.TabIndex = 0;
             this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
             this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.filepathBox_KeyDown);
+            // 
+            // keyboardBox
+            // 
+            this.keyboardBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.keyboardBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.keyboardBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.keyboardBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "keyboard", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.keyboardBox.Enabled = false;
+            this.keyboardBox.FormattingEnabled = true;
+            this.keyboardBox.Items.AddRange(new object[] {
+            "this feature coming in"});
+            this.keyboardBox.Location = new System.Drawing.Point(6, 19);
+            this.keyboardBox.Name = "keyboardBox";
+            this.keyboardBox.PlaceholderText = "Select a keyboard to download";
+            this.keyboardBox.Size = new System.Drawing.Size(438, 21);
+            this.keyboardBox.TabIndex = 0;
+            this.keyboardBox.Text = global::QMK_Toolbox.Properties.Settings.Default.keyboard;
+            this.keyboardBox.TextChanged += new System.EventHandler(this.keyboardBox_TextChanged);
             // 
             // MainWindow
             // 
@@ -503,7 +505,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.Label mcuLabel;
         private System.Windows.Forms.GroupBox qmkfmGroupBox;
         private System.Windows.Forms.ComboBox keymapBox;
-        private System.Windows.Forms.ComboBox keyboardBox;
+        private ComboBoxPlaceholder keyboardBox;
         private System.Windows.Forms.Button loadKeymapButton;
         private System.Windows.Forms.Label keymapLabel;
         private System.Windows.Forms.GroupBox fileGroupBox;

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -27,19 +27,10 @@ namespace QMK_Toolbox
 
     public partial class MainWindow : Form
     {
-        private const int WmDevicechange = 0x0219;
-        private const int DbtDevnodesChanged = 0x0007; //device changed
-        private const int DeviceIdOffset = 55;
-
         private readonly string _filePassedIn = string.Empty;
         private readonly Printing _printer;
         private readonly Flashing _flasher;
         private readonly Usb _usb;
-
-        private const int CB_SETCUEBANNER = 0x1703;
-
-        [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-        private static extern int SendMessage(IntPtr hWnd, int msg, int wParam, [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPWStr)]string lParam);
 
         public MainWindow()
         {
@@ -193,7 +184,6 @@ namespace QMK_Toolbox
                     if (json != null) {
                         var keyboards = JsonConvert.DeserializeObject<List<string>>(json);
                         keyboardBox.Items.Clear();
-                        SendMessage(keyboardBox.Handle, CB_SETCUEBANNER, 0, "Select a keyboard to download");
                         foreach (var keyboard in keyboards)
                         {
                             keyboardBox.Items.Add(keyboard);

--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -172,6 +172,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="USB.cs" />
+    <Compile Include="ComboBoxPlaceholder.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <EmbeddedResource Include="AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Hiding away the ugly `SendMessage()` in a subclass that can be reused for both boxes, because WinForms is dumb and doesn't come OOB with a placeholder text property...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
