### PR TITLE
[Windows] Don't call OnPropertyChanged if property value is the same

### DIFF
--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -207,7 +207,6 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <None Include="QMK Toolbox_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/windows/QMK Toolbox/WindowState.cs
+++ b/windows/QMK Toolbox/WindowState.cs
@@ -16,8 +16,11 @@ namespace QMK_Toolbox
             get => this._autoFlashEnabled;
             set
             {
-                this._autoFlashEnabled = value;
-                OnPropertyChanged();
+                if (this._autoFlashEnabled != value)
+                {
+                    this._autoFlashEnabled = value;
+                    OnPropertyChanged();
+                }
             }
         }
 
@@ -27,8 +30,11 @@ namespace QMK_Toolbox
             get => this._canFlash;
             set
             {
-                this._canFlash = value;
-                OnPropertyChanged();
+                if (this._canFlash != value)
+                {
+                    this._canFlash = value;
+                    OnPropertyChanged();
+                }
             }
         }
 
@@ -38,8 +44,11 @@ namespace QMK_Toolbox
             get => this._canReset;
             set
             {
-                this._canReset = value;
-                OnPropertyChanged();
+                if (this._canReset != value)
+                {
+                    this._canReset = value;
+                    OnPropertyChanged();
+                }
             }
         }
 
@@ -49,8 +58,11 @@ namespace QMK_Toolbox
             get => this._canClearEeprom;
             set
             {
-                this._canClearEeprom = value;
-                OnPropertyChanged();
+                if (this._canClearEeprom != value)
+                {
+                    this._canClearEeprom = value;
+                    OnPropertyChanged();
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Found a slight bug immediately after merging #280 🤦 When toggling autoflash, the log box will print the "autoflash disabled/enabled" message again when you click away. Not sure why exactly that is, but it seems the solution is to simply compare the incoming value with the private field first.

https://www.codeproject.com/Questions/680120/bindingsource-property-setter-called-twice-why

Also, removed a dangling reference to `QMK Toolbox_TemporaryKey.pfx`, this seems to have something to do with ClickOnce which we are not using.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
