### PR TITLE
Add QMK-DFU support

### DIFF
--- a/macos/QMK Toolbox/Flashing.h
+++ b/macos/QMK Toolbox/Flashing.h
@@ -20,6 +20,7 @@ typedef enum {
     Halfkay,
     Kiibohd,
     LUFAMS,
+    QMKDFU,
     STM32DFU,
     STM32Duino,
     USBAsp,

--- a/macos/QMK Toolbox/USB.m
+++ b/macos/QMK Toolbox/USB.m
@@ -249,9 +249,14 @@ static void deviceDisconnectedEvent(void *refCon, io_iterator_t iterator) {
             [delegate setSerialPort:calloutDevice];
         }
     } else if (vendorID == 0x03EB) {
-        if ([atmelDfuPids containsObject:[NSNumber numberWithUnsignedShort:productID]]) { // Atmel DFU
-            deviceName = @"Atmel DFU";
-            deviceType = AtmelDFU;
+        if ([atmelDfuPids containsObject:[NSNumber numberWithUnsignedShort:productID]]) {
+            if (revisionBCD == 0x0936) { // QMK DFU
+                deviceName = @"QMK DFU";
+                deviceType = QMKDFU;
+            } else { // Atmel DFU
+                deviceName = @"Atmel DFU";
+                deviceType = AtmelDFU;
+            }
         } else if (productID == 0x2045) { // LUFA MS
             deviceName = @"LUFA Mass Storage";
             deviceType = LUFAMS;

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -150,12 +150,20 @@ namespace QMK_Toolbox
                 }
                 else if (vendorId == 0x03EB)
                 {
-                    if (atmelDfuPids.Contains(productId)) // Atmel DFU
+                    if (atmelDfuPids.Contains(productId))
                     {
-                        deviceName = "Atmel DFU";
-                        deviceType = Chipset.AtmelDfu;
+                        if (revisionBcd == 0x0936) // QMK-DFU
+                        {
+                            deviceName = "QMK DFU";
+                            deviceType = Chipset.QmkDfu;
+                        }
+                        else // Atmel DFU
+                        {
+                            deviceName = "Atmel DFU";
+                            deviceType = Chipset.AtmelDfu;
+                        }
                     }
-                    else if (productId == 0x2045)
+                    else if (productId == 0x2045) // LUFA MS
                     {
                         deviceName = "LUFA Mass Storage";
                         deviceType = Chipset.LufaMs;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When the next qmk_firmware breaking changes cycle lands, with the updated LUFA submodule, the `:bootloader` target for a board with `BOOTLOADER = qmk-dfu` set will produce a .hex file that has it's USB device revision number set to `0x0936` (The Unicode codepoint for Ψ in decimal). This bootloader is able to clear the EEPROM without first performing a full chip erase.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
