### PR TITLE
Disable EEPROM menu if no compatible devices connected

### DIFF
--- a/macos/QMK Toolbox/Base.lproj/MainMenu.xib
+++ b/macos/QMK Toolbox/Base.lproj/MainMenu.xib
@@ -197,16 +197,21 @@
                                             <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                             <connections>
                                                 <action selector="setHandednessButtonClick:" target="Voe-Tx-rLC" id="HGY-yK-wlb"/>
+                                                <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canClearEEPROM" id="Fsm-d7-Woy"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Set Right Hand" tag="1" keyEquivalent="" id="Srd-qs-7xC">
                                             <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                             <connections>
                                                 <action selector="setHandednessButtonClick:" target="Voe-Tx-rLC" id="deN-mD-LWe"/>
+                                                <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canClearEEPROM" id="oYH-KT-4we"/>
                                             </connections>
                                         </menuItem>
                                     </items>
                                 </menu>
+                                <connections>
+                                    <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canClearEEPROM" id="Zfv-M0-NF7"/>
+                                </connections>
                             </menuItem>
                             <menuItem title="Exit DFU" keyEquivalent="X" id="N5j-gr-8MX">
                                 <connections>

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -58,7 +58,7 @@ namespace QMK_Toolbox {
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.flashToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.eepromToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.eepromToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
             this.eepromClearToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
             this.eepromToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
             this.eepromLeftToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
@@ -441,6 +441,7 @@ namespace QMK_Toolbox {
             // 
             // eepromToolStripMenuItem
             // 
+            this.eepromToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.eepromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.eepromClearToolStripMenuItem,
             this.eepromToolStripMenuSep,
@@ -639,7 +640,7 @@ namespace QMK_Toolbox {
         private System.Windows.Forms.ToolStripMenuItem checkForUpdatesToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator helpToolStripMenuSep;
         private QMK_Toolbox.BindableToolStripMenuItem flashToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem eepromToolStripMenuItem;
+        private QMK_Toolbox.BindableToolStripMenuItem eepromToolStripMenuItem;
         private QMK_Toolbox.BindableToolStripMenuItem eepromClearToolStripMenuItem;
         private QMK_Toolbox.BindableToolStripMenuItem eepromLeftToolStripMenuItem;
         private QMK_Toolbox.BindableToolStripMenuItem eepromRightToolStripMenuItem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A slight UI bug... the EEPROM menu should be completely disabled unless a bootloader device capable of modifying EEPROM contents is connected.

On macOS, the bindings for the handedness items also weren't set up.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
