### PR TITLE
[macOS] UI cleanup

### DIFF
--- a/macos/QMK Toolbox/Base.lproj/MainMenu.xib
+++ b/macos/QMK Toolbox/Base.lproj/MainMenu.xib
@@ -285,76 +285,6 @@
                 <rect key="frame" x="0.0" y="0.0" width="800" height="640"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" scrollerKnobStyle="dark" translatesAutoresizingMaskIntoConstraints="NO" id="w5R-Hk-e8X">
-                        <rect key="frame" x="10" y="41" width="780" height="485"/>
-                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oaz-yh-Zob">
-                            <rect key="frame" x="1" y="1" width="778" height="483"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" allowsNonContiguousLayout="YES" id="tMQ-2J-GgU">
-                                    <rect key="frame" x="0.0" y="0.0" width="778" height="483"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <color key="backgroundColor" white="0.092534722220000004" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="778" height="483"/>
-                                    <size key="maxSize" width="793" height="10000000"/>
-                                    <color key="insertionPointColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </textView>
-                            </subviews>
-                        </clipView>
-                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="IBW-oz-f3p">
-                            <rect key="frame" x="1" y="528" width="693" height="16"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="guZ-nH-ZjT">
-                            <rect key="frame" x="678" y="1" width="16" height="443"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                    </scrollView>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qEj-2h-OmC">
-                        <rect key="frame" x="708" y="551" width="89" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="0c7-uS-SRH"/>
-                            <constraint firstAttribute="width" constant="75" id="mbB-cQ-ug3"/>
-                        </constraints>
-                        <buttonCell key="cell" type="push" title="Exit DFU" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="euK-aj-UAI">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="label" size="12"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="resetButtonClick:" target="Voe-Tx-rLC" id="OeF-Gz-mpL"/>
-                            <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canReset" id="bTa-Zn-nnd"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OKF-oG-mRx">
-                        <rect key="frame" x="636" y="551" width="82" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="igB-eN-Klh"/>
-                            <constraint firstAttribute="width" constant="68" id="sS6-6I-Jy2"/>
-                        </constraints>
-                        <buttonCell key="cell" type="push" title="Flash" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WBr-hK-w8Y">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="label" size="12"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="flashButtonClick:" target="Voe-Tx-rLC" id="qed-bj-dbt"/>
-                            <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canFlash" id="B7O-2B-f3E"/>
-                        </connections>
-                    </button>
-                    <button translatesAutoresizingMaskIntoConstraints="NO" id="TwL-TO-5Ka">
-                        <rect key="frame" x="641" y="534.5" width="94" height="18"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="92" id="VS7-uL-i4O"/>
-                            <constraint firstAttribute="height" constant="15" id="ssc-vc-JLH"/>
-                        </constraints>
-                        <buttonCell key="cell" type="check" title="Auto-Flash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="X8j-zC-WSC">
-                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                            <font key="font" metaFont="label" size="12"/>
-                        </buttonCell>
-                        <connections>
-                            <binding destination="Voe-Tx-rLC" name="value" keyPath="autoFlashEnabled" id="H8W-yV-uz1"/>
-                        </connections>
-                    </button>
                     <box borderType="line" title="Local file" translatesAutoresizingMaskIntoConstraints="NO" id="t67-0j-kLe">
                         <rect key="frame" x="2" y="583" width="796" height="53"/>
                         <view key="contentView" id="R6x-jp-q9X">
@@ -415,6 +345,18 @@
                             <constraint firstAttribute="height" constant="49" id="tXt-Mt-ocN"/>
                         </constraints>
                     </box>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9ht-zl-DdM">
+                        <rect key="frame" x="685" y="620" width="92" height="16"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="16" id="7hf-ak-jNR"/>
+                            <constraint firstAttribute="width" constant="88" id="YDa-UX-xkr"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="MCU (AVR only)" id="ndf-Uu-8bq">
+                            <font key="font" metaFont="message" size="11"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                     <box boxType="secondary" borderType="line" title="Keyboard from qmk.fm" translatesAutoresizingMaskIntoConstraints="NO" id="LCo-O1-xnT">
                         <rect key="frame" x="2" y="531" width="636" height="53"/>
                         <view key="contentView" id="cS7-E3-hab">
@@ -491,18 +433,76 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9ht-zl-DdM">
-                        <rect key="frame" x="685" y="620" width="92" height="16"/>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OKF-oG-mRx">
+                        <rect key="frame" x="636" y="551" width="82" height="33"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="16" id="7hf-ak-jNR"/>
-                            <constraint firstAttribute="width" constant="88" id="YDa-UX-xkr"/>
+                            <constraint firstAttribute="height" constant="21" id="igB-eN-Klh"/>
+                            <constraint firstAttribute="width" constant="68" id="sS6-6I-Jy2"/>
                         </constraints>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="MCU (AVR only)" id="ndf-Uu-8bq">
-                            <font key="font" metaFont="message" size="11"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
+                        <buttonCell key="cell" type="push" title="Flash" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WBr-hK-w8Y">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="label" size="12"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="flashButtonClick:" target="Voe-Tx-rLC" id="qed-bj-dbt"/>
+                            <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canFlash" id="B7O-2B-f3E"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qEj-2h-OmC">
+                        <rect key="frame" x="708" y="551" width="89" height="33"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="21" id="0c7-uS-SRH"/>
+                            <constraint firstAttribute="width" constant="75" id="mbB-cQ-ug3"/>
+                        </constraints>
+                        <buttonCell key="cell" type="push" title="Exit DFU" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="euK-aj-UAI">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="label" size="12"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="resetButtonClick:" target="Voe-Tx-rLC" id="OeF-Gz-mpL"/>
+                            <binding destination="Voe-Tx-rLC" name="enabled" keyPath="canReset" id="bTa-Zn-nnd"/>
+                        </connections>
+                    </button>
+                    <button translatesAutoresizingMaskIntoConstraints="NO" id="TwL-TO-5Ka">
+                        <rect key="frame" x="641" y="534.5" width="94" height="18"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="92" id="VS7-uL-i4O"/>
+                            <constraint firstAttribute="height" constant="15" id="ssc-vc-JLH"/>
+                        </constraints>
+                        <buttonCell key="cell" type="check" title="Auto-Flash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="X8j-zC-WSC">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="label" size="12"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="Voe-Tx-rLC" name="value" keyPath="autoFlashEnabled" id="H8W-yV-uz1"/>
+                        </connections>
+                    </button>
+                    <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" scrollerKnobStyle="dark" translatesAutoresizingMaskIntoConstraints="NO" id="w5R-Hk-e8X">
+                        <rect key="frame" x="10" y="41" width="780" height="485"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oaz-yh-Zob">
+                            <rect key="frame" x="1" y="1" width="778" height="483"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" allowsNonContiguousLayout="YES" id="tMQ-2J-GgU">
+                                    <rect key="frame" x="0.0" y="0.0" width="778" height="483"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" white="0.092534722220000004" alpha="1" colorSpace="calibratedWhite"/>
+                                    <size key="minSize" width="778" height="483"/>
+                                    <size key="maxSize" width="793" height="10000000"/>
+                                    <color key="insertionPointColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </textView>
+                            </subviews>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="IBW-oz-f3p">
+                            <rect key="frame" x="1" y="528" width="693" height="16"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="guZ-nH-ZjT">
+                            <rect key="frame" x="678" y="1" width="16" height="443"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RSb-Il-mNt">
                         <rect key="frame" x="3" y="3" width="127" height="33"/>
                         <constraints>

--- a/macos/QMK Toolbox/Base.lproj/MainMenu.xib
+++ b/macos/QMK Toolbox/Base.lproj/MainMenu.xib
@@ -286,13 +286,13 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <box borderType="line" title="Local file" translatesAutoresizingMaskIntoConstraints="NO" id="t67-0j-kLe">
-                        <rect key="frame" x="2" y="583" width="796" height="53"/>
+                        <rect key="frame" x="7" y="576" width="786" height="54"/>
                         <view key="contentView" id="R6x-jp-q9X">
-                            <rect key="frame" x="3" y="3" width="790" height="35"/>
+                            <rect key="frame" x="3" y="3" width="780" height="36"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fMz-rn-IEt">
-                                    <rect key="frame" x="7" y="6" width="599" height="24"/>
+                                    <rect key="frame" x="8" y="4" width="580" height="26"/>
                                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Click Open or drag to window to select file" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="XxC-Jz-p7t">
                                         <font key="font" metaFont="cellTitle"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -303,10 +303,20 @@
                                         <outlet property="delegate" destination="Voe-Tx-rLC" id="RTL-ba-n38"/>
                                     </connections>
                                 </comboBox>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oJO-GM-iRa">
+                                    <rect key="frame" x="586" y="1" width="65" height="32"/>
+                                    <buttonCell key="cell" type="push" title="Open" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Nyj-sA-jKg">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="label" size="12"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="openButtonClick:" target="Voe-Tx-rLC" id="3wi-np-wbs"/>
+                                    </connections>
+                                </button>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A13-Sl-S0x">
-                                    <rect key="frame" x="678" y="6" width="108" height="24"/>
+                                    <rect key="frame" x="652" y="4" width="123" height="26"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="105" id="fYy-tf-ll3"/>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="ngg-OW-E96"/>
                                     </constraints>
                                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select MCU" drawsBackground="YES" buttonBordered="NO" completes="NO" numberOfVisibleItems="6" id="xEk-tg-smb">
                                         <font key="font" metaFont="cellTitle"/>
@@ -317,40 +327,26 @@
                                         <outlet property="delegate" destination="Voe-Tx-rLC" id="nzF-ij-VIK"/>
                                     </connections>
                                 </comboBox>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oJO-GM-iRa">
-                                    <rect key="frame" x="604" y="2" width="73" height="32"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="59" id="u2Q-Np-4xa"/>
-                                    </constraints>
-                                    <buttonCell key="cell" type="push" title="Open" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Nyj-sA-jKg">
-                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="label" size="12"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <action selector="openButtonClick:" target="Voe-Tx-rLC" id="3wi-np-wbs"/>
-                                    </connections>
-                                </button>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="A13-Sl-S0x" firstAttribute="leading" secondItem="oJO-GM-iRa" secondAttribute="trailing" constant="8" id="6Jx-W7-tiK"/>
-                                <constraint firstAttribute="trailing" secondItem="A13-Sl-S0x" secondAttribute="trailing" constant="7" id="MaR-VI-fJe"/>
-                                <constraint firstItem="A13-Sl-S0x" firstAttribute="top" secondItem="fMz-rn-IEt" secondAttribute="top" id="MaX-0I-Jzt"/>
-                                <constraint firstItem="oJO-GM-iRa" firstAttribute="top" secondItem="fMz-rn-IEt" secondAttribute="top" constant="-1" id="YGl-HK-Nd4"/>
-                                <constraint firstItem="fMz-rn-IEt" firstAttribute="leading" secondItem="R6x-jp-q9X" secondAttribute="leading" constant="7" id="Zec-GV-iDY"/>
-                                <constraint firstItem="oJO-GM-iRa" firstAttribute="leading" secondItem="fMz-rn-IEt" secondAttribute="trailing" constant="8" id="oBB-vL-74h"/>
-                                <constraint firstItem="fMz-rn-IEt" firstAttribute="top" secondItem="R6x-jp-q9X" secondAttribute="top" constant="7" id="pA1-O0-4lY"/>
+                                <constraint firstItem="A13-Sl-S0x" firstAttribute="leading" secondItem="oJO-GM-iRa" secondAttribute="trailing" constant="8" symbolic="YES" id="6Jx-W7-tiK"/>
+                                <constraint firstAttribute="bottom" secondItem="fMz-rn-IEt" secondAttribute="bottom" constant="8" id="HsG-uU-CiP"/>
+                                <constraint firstAttribute="trailing" secondItem="A13-Sl-S0x" secondAttribute="trailing" constant="8" id="MaR-VI-fJe"/>
+                                <constraint firstAttribute="bottom" secondItem="A13-Sl-S0x" secondAttribute="bottom" constant="8" id="Pba-Zt-SXe"/>
+                                <constraint firstItem="fMz-rn-IEt" firstAttribute="leading" secondItem="R6x-jp-q9X" secondAttribute="leading" constant="8" id="Zec-GV-iDY"/>
+                                <constraint firstItem="oJO-GM-iRa" firstAttribute="top" secondItem="R6x-jp-q9X" secondAttribute="top" constant="8" id="aaM-12-GSW"/>
+                                <constraint firstItem="fMz-rn-IEt" firstAttribute="top" secondItem="R6x-jp-q9X" secondAttribute="top" constant="8" id="dLK-Sg-OMu"/>
+                                <constraint firstAttribute="bottom" secondItem="oJO-GM-iRa" secondAttribute="bottom" constant="8" id="gbJ-5H-OCM"/>
+                                <constraint firstItem="A13-Sl-S0x" firstAttribute="top" secondItem="R6x-jp-q9X" secondAttribute="top" constant="8" id="j7Q-JA-GiH"/>
+                                <constraint firstItem="oJO-GM-iRa" firstAttribute="leading" secondItem="fMz-rn-IEt" secondAttribute="trailing" constant="8" symbolic="YES" id="oBB-vL-74h"/>
                             </constraints>
                         </view>
                         <constraints>
-                            <constraint firstAttribute="height" constant="49" id="tXt-Mt-ocN"/>
+                            <constraint firstAttribute="height" constant="50" id="tXt-Mt-ocN"/>
                         </constraints>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9ht-zl-DdM">
-                        <rect key="frame" x="685" y="620" width="92" height="16"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="16" id="7hf-ak-jNR"/>
-                            <constraint firstAttribute="width" constant="88" id="YDa-UX-xkr"/>
-                        </constraints>
+                        <rect key="frame" x="663" y="616" width="129" height="14"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="MCU (AVR only)" id="ndf-Uu-8bq">
                             <font key="font" metaFont="message" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -358,13 +354,13 @@
                         </textFieldCell>
                     </textField>
                     <box boxType="secondary" borderType="line" title="Keyboard from qmk.fm" translatesAutoresizingMaskIntoConstraints="NO" id="LCo-O1-xnT">
-                        <rect key="frame" x="2" y="531" width="636" height="53"/>
+                        <rect key="frame" x="7" y="518" width="651" height="54"/>
                         <view key="contentView" id="cS7-E3-hab">
-                            <rect key="frame" x="3" y="3" width="630" height="35"/>
+                            <rect key="frame" x="3" y="3" width="645" height="36"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j37-hH-gaF">
-                                    <rect key="frame" x="7" y="6" width="414" height="24"/>
+                                    <rect key="frame" x="8" y="4" width="440" height="26"/>
                                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select a keyboard to download" drawsBackground="YES" numberOfVisibleItems="20" id="5mG-K9-oUt">
                                         <font key="font" metaFont="cellTitle"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -377,9 +373,9 @@
                                     </comboBoxCell>
                                 </comboBox>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kHS-JF-7Py">
-                                    <rect key="frame" x="426" y="6" width="130" height="24"/>
+                                    <rect key="frame" x="453" y="4" width="131" height="26"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="127" id="Rmh-Vs-2bF"/>
+                                        <constraint firstAttribute="width" constant="128" id="Rmh-Vs-2bF"/>
                                     </constraints>
                                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="S8q-ac-xFc">
                                         <font key="font" metaFont="cellTitle"/>
@@ -393,10 +389,7 @@
                                     </comboBoxCell>
                                 </comboBox>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NAG-fy-neW">
-                                    <rect key="frame" x="554" y="2" width="72" height="32"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="58" id="wPl-Eb-7HZ"/>
-                                    </constraints>
+                                    <rect key="frame" x="582" y="1" width="62" height="32"/>
                                     <buttonCell key="cell" type="push" title="Load" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GU7-Aq-YSe">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="label" size="12"/>
@@ -407,26 +400,24 @@
                                 </button>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="NAG-fy-neW" firstAttribute="top" secondItem="cS7-E3-hab" secondAttribute="top" constant="6" id="0dj-e9-2b2"/>
-                                <constraint firstItem="NAG-fy-neW" firstAttribute="centerY" secondItem="kHS-JF-7Py" secondAttribute="centerY" id="7yw-gL-aG6"/>
-                                <constraint firstItem="j37-hH-gaF" firstAttribute="leading" secondItem="cS7-E3-hab" secondAttribute="leading" constant="7" id="9l7-JK-igl"/>
-                                <constraint firstAttribute="trailing" secondItem="NAG-fy-neW" secondAttribute="trailing" constant="11" id="FMn-4k-zDM"/>
-                                <constraint firstItem="kHS-JF-7Py" firstAttribute="baseline" secondItem="j37-hH-gaF" secondAttribute="baseline" id="ekw-SS-ewz"/>
+                                <constraint firstItem="j37-hH-gaF" firstAttribute="leading" secondItem="cS7-E3-hab" secondAttribute="leading" constant="8" id="9l7-JK-igl"/>
+                                <constraint firstItem="j37-hH-gaF" firstAttribute="top" secondItem="cS7-E3-hab" secondAttribute="top" constant="8" id="EHH-W1-fRe"/>
+                                <constraint firstAttribute="trailing" secondItem="NAG-fy-neW" secondAttribute="trailing" constant="8" id="FMn-4k-zDM"/>
+                                <constraint firstAttribute="bottom" secondItem="kHS-JF-7Py" secondAttribute="bottom" constant="8" id="QW1-Ya-Dh0"/>
+                                <constraint firstItem="NAG-fy-neW" firstAttribute="top" secondItem="cS7-E3-hab" secondAttribute="top" constant="8" id="UK7-G7-uOK"/>
+                                <constraint firstItem="kHS-JF-7Py" firstAttribute="top" secondItem="cS7-E3-hab" secondAttribute="top" constant="8" id="fyK-pO-4UY"/>
+                                <constraint firstAttribute="bottom" secondItem="NAG-fy-neW" secondAttribute="bottom" constant="8" id="i4C-rj-f3c"/>
                                 <constraint firstItem="NAG-fy-neW" firstAttribute="leading" secondItem="kHS-JF-7Py" secondAttribute="trailing" constant="8" symbolic="YES" id="k6V-Xf-uIb"/>
                                 <constraint firstItem="kHS-JF-7Py" firstAttribute="leading" secondItem="j37-hH-gaF" secondAttribute="trailing" constant="8" symbolic="YES" id="pUG-Y3-pdF"/>
+                                <constraint firstAttribute="bottom" secondItem="j37-hH-gaF" secondAttribute="bottom" constant="8" id="vJB-Nf-E6s"/>
                             </constraints>
                         </view>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="500" id="38u-4Y-81g"/>
-                            <constraint firstAttribute="height" constant="49" id="xKd-xI-5cI"/>
+                            <constraint firstAttribute="height" constant="50" id="xKd-xI-5cI"/>
                         </constraints>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sFy-Lg-NKo">
-                        <rect key="frame" x="433" y="568" width="52" height="16"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="16" id="JnJ-lg-qh7"/>
-                            <constraint firstAttribute="width" constant="48" id="sON-qv-qTg"/>
-                        </constraints>
+                        <rect key="frame" x="464" y="558" width="193" height="14"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Keymap" id="bla-E3-TAS">
                             <font key="font" metaFont="message" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -434,11 +425,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OKF-oG-mRx">
-                        <rect key="frame" x="636" y="551" width="82" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="igB-eN-Klh"/>
-                            <constraint firstAttribute="width" constant="68" id="sS6-6I-Jy2"/>
-                        </constraints>
+                        <rect key="frame" x="656" y="538" width="64" height="32"/>
                         <buttonCell key="cell" type="push" title="Flash" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WBr-hK-w8Y">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
@@ -449,11 +436,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qEj-2h-OmC">
-                        <rect key="frame" x="708" y="551" width="89" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="0c7-uS-SRH"/>
-                            <constraint firstAttribute="width" constant="75" id="mbB-cQ-ug3"/>
-                        </constraints>
+                        <rect key="frame" x="714" y="538" width="83" height="32"/>
                         <buttonCell key="cell" type="push" title="Exit DFU" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="euK-aj-UAI">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
@@ -464,11 +447,7 @@
                         </connections>
                     </button>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="TwL-TO-5Ka">
-                        <rect key="frame" x="641" y="534.5" width="94" height="18"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="92" id="VS7-uL-i4O"/>
-                            <constraint firstAttribute="height" constant="15" id="ssc-vc-JLH"/>
-                        </constraints>
+                        <rect key="frame" x="661" y="520.5" width="129" height="18"/>
                         <buttonCell key="cell" type="check" title="Auto-Flash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="X8j-zC-WSC">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="label" size="12"/>
@@ -478,37 +457,33 @@
                         </connections>
                     </button>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" scrollerKnobStyle="dark" translatesAutoresizingMaskIntoConstraints="NO" id="w5R-Hk-e8X">
-                        <rect key="frame" x="10" y="41" width="780" height="485"/>
+                        <rect key="frame" x="10" y="38" width="780" height="476"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oaz-yh-Zob">
-                            <rect key="frame" x="1" y="1" width="778" height="483"/>
+                            <rect key="frame" x="1" y="1" width="778" height="474"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" allowsNonContiguousLayout="YES" id="tMQ-2J-GgU">
-                                    <rect key="frame" x="0.0" y="0.0" width="778" height="483"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="778" height="474"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="backgroundColor" white="0.092534722220000004" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="778" height="483"/>
+                                    <size key="minSize" width="778" height="474"/>
                                     <size key="maxSize" width="793" height="10000000"/>
                                     <color key="insertionPointColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </textView>
                             </subviews>
                         </clipView>
                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="IBW-oz-f3p">
-                            <rect key="frame" x="1" y="528" width="693" height="16"/>
+                            <rect key="frame" x="1" y="460" width="768" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="guZ-nH-ZjT">
-                            <rect key="frame" x="678" y="1" width="16" height="443"/>
+                            <rect key="frame" x="763" y="1" width="16" height="474"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RSb-Il-mNt">
-                        <rect key="frame" x="3" y="3" width="127" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="113" id="OrW-P7-Fri"/>
-                            <constraint firstAttribute="height" constant="21" id="ZJj-0M-KZ7"/>
-                        </constraints>
+                        <rect key="frame" x="3" y="3" width="117" height="32"/>
                         <buttonCell key="cell" type="push" title="Clear EEPROM" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aot-j7-w9r">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="label" size="12"/>
@@ -519,7 +494,7 @@
                         </connections>
                     </button>
                     <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FPO-qP-5FM">
-                        <rect key="frame" x="131" y="6" width="662" height="26"/>
+                        <rect key="frame" x="121" y="6" width="672" height="25"/>
                         <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="No HID console devices connected" drawsBackground="YES" buttonBordered="NO" completes="NO" numberOfVisibleItems="5" id="7kS-Qf-UrK">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -528,33 +503,36 @@
                     </comboBox>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="TwL-TO-5Ka" firstAttribute="top" secondItem="qEj-2h-OmC" secondAttribute="bottom" constant="8" id="0cf-RK-F41"/>
                     <constraint firstAttribute="trailing" secondItem="w5R-Hk-e8X" secondAttribute="trailing" constant="10" id="1SK-rh-DGn"/>
-                    <constraint firstItem="FPO-qP-5FM" firstAttribute="top" secondItem="w5R-Hk-e8X" secondAttribute="bottom" constant="11" id="2jc-v5-h0x"/>
                     <constraint firstItem="TwL-TO-5Ka" firstAttribute="leading" secondItem="OKF-oG-mRx" secondAttribute="leading" id="533-Os-hQd"/>
                     <constraint firstAttribute="trailing" secondItem="qEj-2h-OmC" secondAttribute="trailing" constant="10" id="56Q-ms-Qm2"/>
+                    <constraint firstAttribute="leading" relation="greaterThanOrEqual" secondItem="RSb-Il-mNt" secondAttribute="trailing" constant="-113" id="BC0-zS-krH"/>
                     <constraint firstItem="w5R-Hk-e8X" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="10" id="BdT-Ww-Qmp"/>
-                    <constraint firstItem="TwL-TO-5Ka" firstAttribute="top" secondItem="OKF-oG-mRx" secondAttribute="bottom" constant="7" id="EZw-Oy-KNM"/>
-                    <constraint firstItem="OKF-oG-mRx" firstAttribute="top" secondItem="t67-0j-kLe" secondAttribute="bottom" constant="8" id="FOU-xm-c2G"/>
-                    <constraint firstItem="qEj-2h-OmC" firstAttribute="top" secondItem="t67-0j-kLe" secondAttribute="bottom" constant="8" id="Fte-6p-aOZ"/>
-                    <constraint firstAttribute="trailing" secondItem="t67-0j-kLe" secondAttribute="trailing" constant="5" id="G6N-Tg-bGd"/>
-                    <constraint firstItem="w5R-Hk-e8X" firstAttribute="top" secondItem="LCo-O1-xnT" secondAttribute="bottom" constant="9" id="HwZ-Rm-mbl"/>
-                    <constraint firstItem="qEj-2h-OmC" firstAttribute="leading" secondItem="OKF-oG-mRx" secondAttribute="trailing" constant="4" id="M4Z-Am-PSX"/>
-                    <constraint firstItem="qEj-2h-OmC" firstAttribute="leading" secondItem="OKF-oG-mRx" secondAttribute="trailing" constant="4" id="Nc3-jf-JYQ"/>
-                    <constraint firstItem="LCo-O1-xnT" firstAttribute="top" secondItem="t67-0j-kLe" secondAttribute="bottom" constant="3" id="Ul1-S7-BR5"/>
+                    <constraint firstItem="w5R-Hk-e8X" firstAttribute="top" secondItem="TwL-TO-5Ka" secondAttribute="bottom" constant="8" symbolic="YES" id="C58-dN-Nz8"/>
+                    <constraint firstAttribute="trailing" secondItem="t67-0j-kLe" secondAttribute="trailing" constant="10" id="G6N-Tg-bGd"/>
+                    <constraint firstItem="w5R-Hk-e8X" firstAttribute="top" secondItem="LCo-O1-xnT" secondAttribute="bottom" constant="8" symbolic="YES" id="HwZ-Rm-mbl"/>
+                    <constraint firstItem="FPO-qP-5FM" firstAttribute="top" secondItem="w5R-Hk-e8X" secondAttribute="bottom" constant="9" id="J0O-yY-UE3"/>
+                    <constraint firstItem="qEj-2h-OmC" firstAttribute="leading" secondItem="OKF-oG-mRx" secondAttribute="trailing" constant="8" id="Nc3-jf-JYQ"/>
+                    <constraint firstItem="sFy-Lg-NKo" firstAttribute="trailing" secondItem="LCo-O1-xnT" secondAttribute="trailing" id="OpI-Nf-t6z"/>
+                    <constraint firstItem="9ht-zl-DdM" firstAttribute="trailing" secondItem="t67-0j-kLe" secondAttribute="trailing" id="Psu-ML-lmF"/>
+                    <constraint firstItem="qEj-2h-OmC" firstAttribute="trailing" secondItem="TwL-TO-5Ka" secondAttribute="trailing" id="RnE-Zh-3N5"/>
+                    <constraint firstItem="LCo-O1-xnT" firstAttribute="top" secondItem="t67-0j-kLe" secondAttribute="bottom" constant="8" symbolic="YES" id="Ul1-S7-BR5"/>
+                    <constraint firstItem="TwL-TO-5Ka" firstAttribute="top" secondItem="OKF-oG-mRx" secondAttribute="bottom" constant="8" id="Zf8-0i-vof"/>
                     <constraint firstItem="RSb-Il-mNt" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="10" id="Zwx-cY-fGS"/>
-                    <constraint firstAttribute="trailing" secondItem="9ht-zl-DdM" secondAttribute="trailing" constant="25" id="aCA-8H-6W1"/>
                     <constraint firstAttribute="bottom" secondItem="FPO-qP-5FM" secondAttribute="bottom" constant="10" id="fUh-wY-4b9"/>
                     <constraint firstAttribute="bottom" secondItem="RSb-Il-mNt" secondAttribute="bottom" constant="10" id="hMV-Bz-Rd0"/>
-                    <constraint firstItem="t67-0j-kLe" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="4" id="hY7-4X-Nrm"/>
-                    <constraint firstItem="FPO-qP-5FM" firstAttribute="leading" secondItem="RSb-Il-mNt" secondAttribute="trailing" constant="8" symbolic="YES" id="lMI-UC-Xaw"/>
-                    <constraint firstItem="w5R-Hk-e8X" firstAttribute="top" secondItem="sFy-Lg-NKo" secondAttribute="bottom" constant="42" id="mNm-zP-Ll8"/>
-                    <constraint firstItem="9ht-zl-DdM" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="4" id="me3-Ss-MQt"/>
-                    <constraint firstItem="RSb-Il-mNt" firstAttribute="top" secondItem="w5R-Hk-e8X" secondAttribute="bottom" constant="10" id="nVm-oo-6dO"/>
-                    <constraint firstItem="LCo-O1-xnT" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="5" id="pIB-Hs-nnI"/>
-                    <constraint firstItem="OKF-oG-mRx" firstAttribute="leading" secondItem="LCo-O1-xnT" secondAttribute="trailing" constant="8" id="reN-8u-DkO"/>
-                    <constraint firstItem="t67-0j-kLe" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="5" id="tnv-lz-t10"/>
+                    <constraint firstItem="t67-0j-kLe" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="10" id="hY7-4X-Nrm"/>
+                    <constraint firstItem="9ht-zl-DdM" firstAttribute="leading" secondItem="A13-Sl-S0x" secondAttribute="leading" constant="3" id="jhU-5m-HNH"/>
+                    <constraint firstItem="sFy-Lg-NKo" firstAttribute="bottom" secondItem="LCo-O1-xnT" secondAttribute="top" constant="14" id="mNm-zP-Ll8"/>
+                    <constraint firstItem="9ht-zl-DdM" firstAttribute="bottom" secondItem="t67-0j-kLe" secondAttribute="top" constant="14" id="me3-Ss-MQt"/>
+                    <constraint firstItem="FPO-qP-5FM" firstAttribute="leading" secondItem="RSb-Il-mNt" secondAttribute="trailing" constant="8" symbolic="YES" id="mzX-zO-3Sz"/>
+                    <constraint firstItem="LCo-O1-xnT" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="10" id="pIB-Hs-nnI"/>
+                    <constraint firstItem="OKF-oG-mRx" firstAttribute="leading" secondItem="LCo-O1-xnT" secondAttribute="trailing" constant="8" symbolic="YES" id="reN-8u-DkO"/>
+                    <constraint firstItem="t67-0j-kLe" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="10" id="tnv-lz-t10"/>
                     <constraint firstAttribute="trailing" secondItem="FPO-qP-5FM" secondAttribute="trailing" constant="10" id="utN-AQ-ZVa"/>
-                    <constraint firstItem="kHS-JF-7Py" firstAttribute="leading" secondItem="sFy-Lg-NKo" secondAttribute="leading" constant="-4" id="z5W-JH-tlg"/>
+                    <constraint firstItem="RSb-Il-mNt" firstAttribute="top" secondItem="w5R-Hk-e8X" secondAttribute="bottom" constant="8" id="xU6-gQ-pgQ"/>
+                    <constraint firstItem="sFy-Lg-NKo" firstAttribute="leading" secondItem="kHS-JF-7Py" secondAttribute="leading" constant="3" id="z5W-JH-tlg"/>
                 </constraints>
             </view>
             <point key="canvasLocation" x="349" y="454"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Reordering UI elements in IB (no functional change), and redid the Auto Layout constraints which eliminated a few "fixed width" warnings.

Old (0.1.1):
<img width="912" alt="toolbox-old" src="https://user-images.githubusercontent.com/4781841/131226201-f992e7db-14b0-445b-9370-8ab1b5ab7388.png">
New:
<img width="912" alt="toolbox-new" src="https://user-images.githubusercontent.com/4781841/131226209-4e6ac20a-3d31-4288-8433-c1787af96cd4.png">


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
