### PR TITLE
[Windows] Downgrade Syroot KnownFolders

### DIFF
--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -195,16 +195,13 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Syroot.Windows.IO.KnownFolders">
-      <Version>1.2.3</Version>
+      <Version>1.2.1</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression.ZipFile">
       <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Principal.Windows">
-      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The QMK Toolbox project is at .NET Framework 4.8, while KnownFolders version 1.2.3 targets only .NETStandard 2.0, and may cause an unhandled exception if it is not installed. This brings the package back to 1.2.1, which targets .NET Framework.

https://www.nuget.org/packages/Syroot.Windows.IO.KnownFolders

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
