### PR TITLE
Add Caterina VID:PID for Keyboardio Atreus 2 Bootloader

### DIFF
--- a/macos/QMK Toolbox/USB.m
+++ b/macos/QMK Toolbox/USB.m
@@ -28,6 +28,7 @@ static int devicesAvailable[NumberOfChipsets];
     CFRunLoopSourceRef runLoopSource;
 
     caterinaVids = @[
+        @0x1209, // pid.codes shared PID
         @0x1B4F, // Spark Fun Electronics
         @0x1FFB, // Pololu Electronics
         @0x2341, // Arduino SA
@@ -44,6 +45,8 @@ static int devicesAvailable[NumberOfChipsets];
         @0x0037, // Micro
         // Pololu Electronics
         @0x0101, // A-Star 32U4
+        // Keyboardio (uses the pid.codes shared PID)
+        @0x2302, // Atreus 2 Bootloader
         // Spark Fun Electronics
         @0x9203, // Pro Micro 3V3/8MHz
         @0x9205, // Pro Micro 5V/16MHz

--- a/windows/QMK Toolbox/USB.cs
+++ b/windows/QMK Toolbox/USB.cs
@@ -67,6 +67,7 @@ namespace QMK_Toolbox
 
         private static readonly ushort[] caterinaVids =
         {
+            0x1209, // pid.codes shared PID
             0x1B4F, // Spark Fun Electronics
             0x1FFB, // Pololu Electronics
             0x2341, // Arduino SA
@@ -85,6 +86,8 @@ namespace QMK_Toolbox
             0x0037, // Micro
             // Pololu Electronics
             0x0101, // A-Star 32U4
+            // Keyboardio (uses the pid.codes shared PID)
+            0x2302, // Atreus 2 Bootloader
             // Spark Fun Electronics
             0x9203, // Pro Micro 3V3/8MHz
             0x9205, // Pro Micro 5V/16MHz


### PR DESCRIPTION
## Description

The Keyboardio Atreus 2 Bootloader is a clone of the Caterina bootloader with different USB VID:PID values (`1209:2302`):

  https://github.com/keyboardio/Atreus2-Bootloader

Add the VID and PID values for this bootloader to the appropriate lists.

The VID and PID values were verified in Linux by a Discord user who actually has the board (the proper udev rule was needed to get the board flashed): https://discord.com/channels/440868230475677696/867530222407778344/911701982891360286

Corresponding PRs for udev rules:
* qmk/qmk_firmware#15241
* qmk/qmk_udev#6

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The bootloader for the Atreus 2 board would probably not be detected by the toolbox (but I personally don't have the board, and the user who has the board uses Linux).
