### PR TITLE
Fix up bootloader detection on M1 Macs.

### DIFF
--- a/macos/QMK Toolbox/USB/USBListener.m
+++ b/macos/QMK Toolbox/USB/USBListener.m
@@ -67,7 +67,7 @@ static void deviceConnected(void *context, io_iterator_t iterator) {
     io_service_t service;
     while ((service = IOIteratorNext(iterator))) {
         CFStringRef className = IOObjectCopyClass(service);
-        if (CFEqual(className, CFSTR("IOUSBDevice"))) {
+        if (CFEqual(className, CFSTR("IOUSBDevice")) || CFEqual(className, CFSTR("IOUSBHostDevice"))) {
             BOOL alreadyListed = NO;
             for (USBDevice *d in listener.devices) {
                 if (d.service == service) {
@@ -95,7 +95,7 @@ static void deviceDisconnected(void *context, io_iterator_t iterator) {
     io_service_t service;
     while ((service = IOIteratorNext(iterator))) {
         CFStringRef className = IOObjectCopyClass(service);
-        if (CFEqual(className, CFSTR("IOUSBDevice"))) {
+        if (CFEqual(className, CFSTR("IOUSBDevice")) || CFEqual(className, CFSTR("IOUSBHostDevice"))) {
             NSMutableArray<id<USBDevice>> *discardedItems = [NSMutableArray array];
             for (id<USBDevice> d in listener.devices) {
                 if (d.service == service) {

--- a/macos/QMK Toolbox/USB/USBListener.m
+++ b/macos/QMK Toolbox/USB/USBListener.m
@@ -67,7 +67,7 @@ static void deviceConnected(void *context, io_iterator_t iterator) {
     io_service_t service;
     while ((service = IOIteratorNext(iterator))) {
         CFStringRef className = IOObjectCopyClass(service);
-        if (CFEqual(className, CFSTR("IOUSBDevice")) || CFEqual(className, CFSTR("IOUSBHostDevice"))) {
+        if (CFEqual(className, CFSTR(kIOUSBDeviceClassName)) || CFEqual(className, CFSTR(kIOUSBHostDeviceClassName))) {
             BOOL alreadyListed = NO;
             for (USBDevice *d in listener.devices) {
                 if (d.service == service) {
@@ -95,7 +95,7 @@ static void deviceDisconnected(void *context, io_iterator_t iterator) {
     io_service_t service;
     while ((service = IOIteratorNext(iterator))) {
         CFStringRef className = IOObjectCopyClass(service);
-        if (CFEqual(className, CFSTR("IOUSBDevice")) || CFEqual(className, CFSTR("IOUSBHostDevice"))) {
+        if (CFEqual(className, CFSTR(kIOUSBDeviceClassName)) || CFEqual(className, CFSTR(kIOUSBHostDeviceClassName))) {
             NSMutableArray<id<USBDevice>> *discardedItems = [NSMutableArray array];
             for (id<USBDevice> d in listener.devices) {
                 if (d.service == service) {


### PR DESCRIPTION
## Description

The wrong device class name was being sent back on M1 Macs, breaking detection.
This PR allows for either/or.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation