### PR TITLE
[Windows] Move MCU selector population code out of constructor

### DIFF
--- a/windows/QMK Toolbox/MicrocontrollerSelector.cs
+++ b/windows/QMK Toolbox/MicrocontrollerSelector.cs
@@ -1,4 +1,5 @@
 ﻿using QMK_Toolbox.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 
@@ -6,21 +7,26 @@ namespace QMK_Toolbox
 {
     public class MicrocontrollerSelector : ComboBox
     {
-        public MicrocontrollerSelector()
+        protected override void OnHandleCreated(EventArgs e)
         {
-            List<KeyValuePair<string, string>> microcontrollerDataSource = new List<KeyValuePair<string, string>>();
-            string[] microcontrollers = EmbeddedResourceHelper.GetResourceContent("mcu-list.txt").Split('\n');
+            base.OnHandleCreated(e);
 
-            foreach (string microcontroller in microcontrollers)
+            if (!DesignMode)
             {
-                if (microcontroller.Length > 0)
-                {
-                    string[] parts = microcontroller.Split(':');
-                    microcontrollerDataSource.Add(new KeyValuePair<string, string>(parts[0], parts[1]));
-                }
-            }
+                List<KeyValuePair<string, string>> microcontrollerDataSource = new List<KeyValuePair<string, string>>();
+                string[] microcontrollers = EmbeddedResourceHelper.GetResourceContent("mcu-list.txt").Split('\n');
 
-            DataSource = microcontrollerDataSource;
+                foreach (string microcontroller in microcontrollers)
+                {
+                    if (microcontroller.Length > 0)
+                    {
+                        string[] parts = microcontroller.Split(':');
+                        microcontrollerDataSource.Add(new KeyValuePair<string, string>(parts[0], parts[1]));
+                    }
+                }
+
+                DataSource = microcontrollerDataSource;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Having this in the constructor causes the code to be run, and then applied, whenever I make changes to the form, which adds stuff to the `.Designer.cs` and `.resx` files. Checking for `DesignMode` in the constructor also doesn't work, because... it's the constructor... so it needs to be done a bit later.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
