### PR TITLE
[macOS] Fix open menu item and recent documents clear behaviour

### DIFF
--- a/macos/QMK Toolbox/AppDelegate.m
+++ b/macos/QMK Toolbox/AppDelegate.m
@@ -89,6 +89,12 @@
     }
 }
 
+- (IBAction)clearRecentDocuments:(id)sender {
+    [[NSDocumentController sharedDocumentController] clearRecentDocuments:sender];
+    [self.filepathBox removeAllItems];
+    [self.filepathBox setStringValue:@""];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication {
     return YES;
 }

--- a/macos/QMK Toolbox/Base.lproj/MainMenu.xib
+++ b/macos/QMK Toolbox/Base.lproj/MainMenu.xib
@@ -77,7 +77,7 @@
                         <items>
                             <menuItem title="Open…" keyEquivalent="o" id="hhY-cL-bGV">
                                 <connections>
-                                    <action selector="openDocument:" target="-1" id="g2C-w6-Bis"/>
+                                    <action selector="openButtonClick:" target="-1" id="2xs-eP-Fnk"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open Recent" id="vc1-Sr-4c4">
@@ -321,7 +321,7 @@
                                         <font key="font" metaFont="label" size="12"/>
                                     </buttonCell>
                                     <connections>
-                                        <action selector="openButtonClick:" target="Voe-Tx-rLC" id="3wi-np-wbs"/>
+                                        <action selector="openButtonClick:" target="-1" id="tQf-hm-vEB"/>
                                     </connections>
                                 </button>
                                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A13-Sl-S0x" customClass="MicrocontrollerSelector">
@@ -362,7 +362,7 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="TwL-TO-5Ka">
-                        <rect key="frame" x="453" y="553" width="93" height="18"/>
+                        <rect key="frame" x="458" y="553.5" width="88" height="18"/>
                         <buttonCell key="cell" type="check" title="Auto-Flash" bezelStyle="regularSquare" imagePosition="trailing" inset="2" id="X8j-zC-WSC">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="label" size="12"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- `File->Open Recent->Clear` did not immediately clear the file path combobox
- `File->Open` threw an exception because the `openDocument:` method was not implemented - redirected it to `openButtonClick:`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #77
  Marking this as fixed because I think the "clear all" approach is better and simpler. Will need to be redone on Windows - there is no inbuilt functionality for it in WinForms.