### PR TITLE
[Windows] Fix bug in SetFilePath()

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -445,45 +445,41 @@ namespace QMK_Toolbox
 
         private void SetFilePath(string filepath)
         {
-            if (!filepath.StartsWith("\\\\wsl$"))
+            if (!string.IsNullOrEmpty(filepath))
             {
-                var uri = new Uri(filepath);
-                if (uri.Scheme == "qmk")
+                if (!filepath.StartsWith("\\\\wsl$"))
                 {
-                    string url;
-                    url = filepath.Replace(filepath.Contains("qmk://") ? "qmk://" : "qmk:", "");
-                    filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
+                    var uri = new Uri(filepath);
+                    if (uri.Scheme == "qmk")
+                    {
+                        string url = filepath.Replace(filepath.Contains("qmk://") ? "qmk://" : "qmk:", "");
+                        filepath = Path.Combine(KnownFolders.Downloads.Path, filepath.Substring(filepath.LastIndexOf("/") + 1).Replace(".", "_" + Guid.NewGuid().ToString().Substring(0, 8) + "."));
 
-                    try
-                    {
-                        logTextBox.LogInfo($"Downloading the file: {url}");
-                        DownloadFirmwareFile(url, filepath);
-                    }
-                    catch (Exception)
-                    {
                         try
                         {
-                            // Try .bin extension if hex 404'd
-                            url = Path.ChangeExtension(url, "bin");
-                            filepath = Path.ChangeExtension(filepath, "bin");
-                            logTextBox.LogInfo($"No .hex file found, trying {url}");
+                            logTextBox.LogInfo($"Downloading the file: {url}");
                             DownloadFirmwareFile(url, filepath);
                         }
                         catch (Exception)
                         {
-                            logTextBox.LogError("Something went wrong when trying to get the default keymap file.");
-                            return;
+                            try
+                            {
+                                // Try .bin extension if hex 404'd
+                                url = Path.ChangeExtension(url, "bin");
+                                filepath = Path.ChangeExtension(filepath, "bin");
+                                logTextBox.LogInfo($"No .hex file found, trying {url}");
+                                DownloadFirmwareFile(url, filepath);
+                            }
+                            catch (Exception)
+                            {
+                                logTextBox.LogError("Something went wrong when trying to get the default keymap file.");
+                                return;
+                            }
                         }
+                        logTextBox.LogInfo($"File saved to: {filepath}");
                     }
-                    logTextBox.LogInfo($"File saved to: {filepath}");
                 }
-            }
-            else
-            {
-                if (string.IsNullOrEmpty(filepath))
-                {
-                    return;
-                }
+
                 filepathBox.Text = filepath;
                 if (!filepathBox.Items.Contains(filepath))
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I didn't remove enough code here... the `else` at the very end caused only WSL filepaths to be set. The null/empty check probably should also wrap everything, otherwise it could potentially cause a `UriFormatException`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
