### PR TITLE
[Windows] Enable high-DPI support

### DIFF
--- a/windows/QMK Toolbox/App.config
+++ b/windows/QMK Toolbox/App.config
@@ -49,4 +49,7 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="DpiAwareness" value="PerMonitorV2" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>


### PR DESCRIPTION
## Description
Updates the `App.config` file to opt in to high-DPI support as described in [this documentation](https://docs.microsoft.com/en-us/dotnet/desktop/winforms/high-dpi-support-in-windows-forms?view=netframeworkdesktop-4.8). It doesn't seem like it's necessary to add a manifest file to get this to work, so I didn't add one.

<details>
<summary>Before and after screenshots at 125% scaling</summary>

**Before**
![before](https://user-images.githubusercontent.com/60245/182271374-4ce3c7b7-638f-47db-ab93-2fcb27750adc.png)

**After**
![after](https://user-images.githubusercontent.com/60245/182271382-d4ae06a9-c289-4dd3-b717-9c43c6c4a91c.png)
</details>

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
