### PR TITLE
Use Segoe UI 9pt and "Window" color

### DIFF
--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -88,6 +88,7 @@ namespace QMK_Toolbox {
             this.flashButton.Size = new System.Drawing.Size(72, 27);
             this.flashButton.TabIndex = 6;
             this.flashButton.Text = "Flash";
+            this.flashButton.UseVisualStyleBackColor = true;
             this.flashButton.Click += new System.EventHandler(this.FlashButton_Click);
             // 
             // windowStateBindingSource
@@ -137,6 +138,7 @@ namespace QMK_Toolbox {
             this.resetButton.Size = new System.Drawing.Size(78, 27);
             this.resetButton.TabIndex = 8;
             this.resetButton.Text = "Exit DFU";
+            this.resetButton.UseVisualStyleBackColor = true;
             this.resetButton.Click += new System.EventHandler(this.ResetButton_Click);
             // 
             // mcuLabel

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -82,9 +82,10 @@ namespace QMK_Toolbox {
             this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.flashButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanFlash", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.flashButton.Enabled = false;
-            this.flashButton.Location = new System.Drawing.Point(537, 86);
+            this.flashButton.Location = new System.Drawing.Point(626, 99);
+            this.flashButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.flashButton.Name = "flashButton";
-            this.flashButton.Size = new System.Drawing.Size(62, 23);
+            this.flashButton.Size = new System.Drawing.Size(72, 27);
             this.flashButton.TabIndex = 6;
             this.flashButton.Text = "Flash";
             this.flashButton.Click += new System.EventHandler(this.FlashButton_Click);
@@ -99,10 +100,11 @@ namespace QMK_Toolbox {
             this.autoflashCheckbox.AutoSize = true;
             this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
             this.autoflashCheckbox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.windowStateBindingSource, "AutoFlashEnabled", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.autoflashCheckbox.Location = new System.Drawing.Point(455, 90);
+            this.autoflashCheckbox.Location = new System.Drawing.Point(536, 104);
+            this.autoflashCheckbox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.autoflashCheckbox.Name = "autoflashCheckbox";
             this.autoflashCheckbox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
+            this.autoflashCheckbox.Size = new System.Drawing.Size(84, 19);
             this.autoflashCheckbox.TabIndex = 5;
             this.autoflashCheckbox.Text = "Auto-Flash";
             this.autoflashCheckbox.UseVisualStyleBackColor = false;
@@ -115,9 +117,10 @@ namespace QMK_Toolbox {
             // openFileButton
             // 
             this.openFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.openFileButton.Location = new System.Drawing.Point(571, 18);
+            this.openFileButton.Location = new System.Drawing.Point(666, 21);
+            this.openFileButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.openFileButton.Name = "openFileButton";
-            this.openFileButton.Size = new System.Drawing.Size(64, 23);
+            this.openFileButton.Size = new System.Drawing.Size(75, 27);
             this.openFileButton.TabIndex = 2;
             this.openFileButton.Text = "Open";
             this.openFileButton.UseVisualStyleBackColor = true;
@@ -128,9 +131,10 @@ namespace QMK_Toolbox {
             this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.resetButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanReset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.resetButton.Enabled = false;
-            this.resetButton.Location = new System.Drawing.Point(721, 86);
+            this.resetButton.Location = new System.Drawing.Point(841, 99);
+            this.resetButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.resetButton.Name = "resetButton";
-            this.resetButton.Size = new System.Drawing.Size(67, 23);
+            this.resetButton.Size = new System.Drawing.Size(78, 27);
             this.resetButton.TabIndex = 8;
             this.resetButton.Text = "Exit DFU";
             this.resetButton.Click += new System.EventHandler(this.ResetButton_Click);
@@ -139,9 +143,10 @@ namespace QMK_Toolbox {
             // 
             this.mcuLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.mcuLabel.AutoSize = true;
-            this.mcuLabel.Location = new System.Drawing.Point(638, 0);
+            this.mcuLabel.Location = new System.Drawing.Point(744, 0);
+            this.mcuLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.mcuLabel.Name = "mcuLabel";
-            this.mcuLabel.Size = new System.Drawing.Size(84, 13);
+            this.mcuLabel.Size = new System.Drawing.Size(92, 15);
             this.mcuLabel.TabIndex = 3;
             this.mcuLabel.Text = "MCU (AVR only)";
             // 
@@ -153,9 +158,11 @@ namespace QMK_Toolbox {
             this.fileGroupBox.Controls.Add(this.filepathBox);
             this.fileGroupBox.Controls.Add(this.mcuLabel);
             this.fileGroupBox.Controls.Add(this.mcuBox);
-            this.fileGroupBox.Location = new System.Drawing.Point(12, 32);
+            this.fileGroupBox.Location = new System.Drawing.Point(14, 37);
+            this.fileGroupBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.fileGroupBox.Name = "fileGroupBox";
-            this.fileGroupBox.Size = new System.Drawing.Size(776, 48);
+            this.fileGroupBox.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.fileGroupBox.Size = new System.Drawing.Size(905, 55);
             this.fileGroupBox.TabIndex = 0;
             this.fileGroupBox.TabStop = false;
             this.fileGroupBox.Text = "Local file";
@@ -166,10 +173,11 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.filepathBox.FormattingEnabled = true;
-            this.filepathBox.Location = new System.Drawing.Point(6, 19);
+            this.filepathBox.Location = new System.Drawing.Point(7, 22);
+            this.filepathBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.filepathBox.Name = "filepathBox";
             this.filepathBox.PlaceholderText = "Click Open or drag to window to select file";
-            this.filepathBox.Size = new System.Drawing.Size(558, 21);
+            this.filepathBox.Size = new System.Drawing.Size(650, 23);
             this.filepathBox.TabIndex = 1;
             this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
             this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilepathBox_KeyDown);
@@ -180,9 +188,10 @@ namespace QMK_Toolbox {
             this.mcuBox.DisplayMember = "Value";
             this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.mcuBox.FormattingEnabled = true;
-            this.mcuBox.Location = new System.Drawing.Point(641, 19);
+            this.mcuBox.Location = new System.Drawing.Point(748, 22);
+            this.mcuBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.mcuBox.Name = "mcuBox";
-            this.mcuBox.Size = new System.Drawing.Size(129, 21);
+            this.mcuBox.Size = new System.Drawing.Size(150, 23);
             this.mcuBox.TabIndex = 4;
             this.mcuBox.ValueMember = "Key";
             // 
@@ -191,9 +200,10 @@ namespace QMK_Toolbox {
             this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.clearEepromButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.clearEepromButton.Enabled = false;
-            this.clearEepromButton.Location = new System.Drawing.Point(605, 86);
+            this.clearEepromButton.Location = new System.Drawing.Point(706, 99);
+            this.clearEepromButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.clearEepromButton.Name = "clearEepromButton";
-            this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
+            this.clearEepromButton.Size = new System.Drawing.Size(128, 27);
             this.clearEepromButton.TabIndex = 7;
             this.clearEepromButton.Text = "Clear EEPROM";
             this.clearEepromButton.UseVisualStyleBackColor = true;
@@ -212,10 +222,11 @@ namespace QMK_Toolbox {
             this.logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.logTextBox.ForeColor = System.Drawing.Color.White;
             this.logTextBox.HideSelection = false;
-            this.logTextBox.Location = new System.Drawing.Point(12, 115);
+            this.logTextBox.Location = new System.Drawing.Point(14, 133);
+            this.logTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(776, 509);
+            this.logTextBox.Size = new System.Drawing.Size(905, 587);
             this.logTextBox.TabIndex = 9;
             this.logTextBox.Text = "";
             this.logTextBox.WordWrap = false;
@@ -293,10 +304,11 @@ namespace QMK_Toolbox {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.consoleList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.consoleList.FormattingEnabled = true;
-            this.consoleList.Location = new System.Drawing.Point(12, 631);
+            this.consoleList.Location = new System.Drawing.Point(14, 728);
+            this.consoleList.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.consoleList.Name = "consoleList";
             this.consoleList.PlaceholderText = "No HID console devices connected";
-            this.consoleList.Size = new System.Drawing.Size(776, 21);
+            this.consoleList.Size = new System.Drawing.Size(905, 23);
             this.consoleList.TabIndex = 10;
             // 
             // mainMenu
@@ -308,7 +320,8 @@ namespace QMK_Toolbox {
             this.helpToolStripMenuItem});
             this.mainMenu.Location = new System.Drawing.Point(0, 0);
             this.mainMenu.Name = "mainMenu";
-            this.mainMenu.Size = new System.Drawing.Size(800, 24);
+            this.mainMenu.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            this.mainMenu.Size = new System.Drawing.Size(933, 24);
             this.mainMenu.TabIndex = 0;
             this.mainMenu.Text = "mainMenu";
             // 
@@ -516,9 +529,10 @@ namespace QMK_Toolbox {
             // MainWindow
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 664);
+            this.BackColor = System.Drawing.SystemColors.Window;
+            this.ClientSize = new System.Drawing.Size(933, 766);
             this.Controls.Add(this.mainMenu);
             this.Controls.Add(this.consoleList);
             this.Controls.Add(this.clearEepromButton);
@@ -527,9 +541,11 @@ namespace QMK_Toolbox {
             this.Controls.Add(this.autoflashCheckbox);
             this.Controls.Add(this.logTextBox);
             this.Controls.Add(this.resetButton);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.mainMenu;
-            this.MinimumSize = new System.Drawing.Size(816, 703);
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.MinimumSize = new System.Drawing.Size(949, 805);
             this.Name = "MainWindow";
             this.Text = "QMK Toolbox";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainWindow_FormClosing);


### PR DESCRIPTION
## Description
Segoe UI 9pt is recommended for Windows 7+ in the UI guidelines:
https://learn.microsoft.com/en-us/windows/win32/uxguide/vis-fonts

Basically, the "Control" background color + MS Sans Serif is ony there for compat with Windows XP.

## Types of Changes
- [x] Enhancement/optimization

Looks like this after merging:
![image](https://user-images.githubusercontent.com/4068864/198855928-c5dab1aa-60e1-4ec1-96f6-feeecc388967.png)

Before:
![image](https://user-images.githubusercontent.com/4068864/198855968-7024373f-0b4f-4c18-96d3-1ec3f006f288.png)
