### PR TITLE
Update brew installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,5 @@ Get the latest release [here](https://github.com/qmk/qmk_toolbox/releases).
 For Homebrew users, it is also available as a Cask:
 
 ```sh
-$ brew tap homebrew/cask-drivers
 $ brew install --cask qmk-toolbox
 ```


### PR DESCRIPTION
cask-drivers was deprecated and removed. qmk-toolbox can be installed without tapping.