### PR TITLE
Remove $ from brew download code block in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,5 +65,5 @@ Get the latest release [here](https://github.com/qmk/qmk_toolbox/releases).
 For Homebrew users, it is also available as a Cask:
 
 ```sh
-$ brew install qmk-toolbox
+brew install qmk-toolbox
 ```


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Having the $ in the code block makes Github's copy function useless, as it copies the $ also, causing terminals to error.

Removing the $ (while arguably it isn't as aesthetically pleasing) allows someone to copy and paste directly into their terminal.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation
