### PR TITLE
[Windows] Fix possible ArgumentNullException when enumerating USB devices

### DIFF
--- a/windows/QMK Toolbox/Usb/UsbListener.cs
+++ b/windows/QMK Toolbox/Usb/UsbListener.cs
@@ -29,7 +29,7 @@ namespace QMK_Toolbox.Usb
         {
             var enumeratedDevices = new ManagementObjectSearcher(@"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE 'USB%'").Get()
                 .Cast<ManagementBaseObject>().ToList()
-                .Where(d => ((string[])d.GetPropertyValue("HardwareID")).Any(s => UsbIdRegex.Match(s).Success));
+                .Where(d => (d.GetPropertyValue("HardwareID") as string[])?.Any(s => UsbIdRegex.Match(s).Success) ?? false);
 
             if (connected)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Apparently `HardwareID` can sometimes be null...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
