### PR TITLE
[Windows] Fix HID Console crashing on close

### DIFF
--- a/windows/QMK Toolbox/HidConsole/HidConsoleWindow.cs
+++ b/windows/QMK Toolbox/HidConsole/HidConsoleWindow.cs
@@ -35,6 +35,9 @@ namespace QMK_Toolbox.HidConsole
 
         private void HidConsoleWindow_FormClosing(object sender, FormClosingEventArgs e)
         {
+            consoleListener.consoleDeviceConnected -= ConsoleDeviceConnected;
+            consoleListener.consoleDeviceDisconnected -= ConsoleDeviceDisconnected;
+            consoleListener.consoleReportReceived -= ConsoleReportReceived;
             consoleListener.Dispose();
         }
         #endregion


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tested on `handwired/onekey/proton_c:console`, the Toolbox crashes if the device sends a report after the HID Console window has closed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
