### PR TITLE
[macOS] A couple of small bugfixes

### DIFF
--- a/macos/QMK Toolbox/Info.plist
+++ b/macos/QMK Toolbox/Info.plist
@@ -13,6 +13,8 @@
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>fm.qmk.hex</string>
@@ -20,7 +22,7 @@
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
-			<string>NSDocument</string>
+			<string></string>
 		</dict>
 		<dict>
 			<key>CFBundleTypeExtensions</key>
@@ -29,6 +31,8 @@
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.apple.macbinary-archive</string>
@@ -36,7 +40,7 @@
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
-			<string>NSDocument</string>
+			<string></string>
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>

--- a/macos/QMK Toolbox/MainViewController.swift
+++ b/macos/QMK Toolbox/MainViewController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import UniformTypeIdentifiers
 
 class MainViewController: NSViewController, USBListenerDelegate {
     @IBOutlet var filepathBox: NSComboBox!
@@ -273,7 +274,10 @@ class MainViewController: NSViewController, USBListenerDelegate {
         openPanel.canChooseDirectories = false
         openPanel.allowsMultipleSelection = false
         openPanel.message = "Select firmware to load"
-        openPanel.allowedFileTypes = ["bin", "hex"]
+        openPanel.allowedContentTypes = [
+            UTType(filenameExtension: "bin")!,
+            UTType(filenameExtension: "hex")!
+        ]
         openPanel.beginSheetModal(for: window) { response in
             guard response == .OK, let file = openPanel.url else { return }
             self.setFilePath(file)

--- a/macos/QMK Toolbox/USB/Bootloader/BootloaderDevice.swift
+++ b/macos/QMK Toolbox/USB/Bootloader/BootloaderDevice.swift
@@ -124,7 +124,7 @@ class BootloaderDevice: USBDeviceProtocol, CustomStringConvertible {
         let serialMatcher = IOServiceMatching(kIOSerialBSDServiceValue)
         var serialIterator: io_iterator_t = 0
 
-        guard IOServiceGetMatchingServices(kIOMasterPortDefault, serialMatcher, &serialIterator) == KERN_SUCCESS else { return nil }
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, serialMatcher, &serialIterator) == KERN_SUCCESS else { return nil }
 
         repeat {
             let port = IOIteratorNext(serialIterator)

--- a/macos/QMK Toolbox/USB/Bootloader/LUFAMSDevice.swift
+++ b/macos/QMK Toolbox/USB/Bootloader/LUFAMSDevice.swift
@@ -41,7 +41,7 @@ class LUFAMSDevice: BootloaderDevice {
         massStorageMatcher[kIOMediaRemovableKey] = true
 
         var massStorageIterator: io_iterator_t = 0
-        guard IOServiceGetMatchingServices(kIOMasterPortDefault, massStorageMatcher as CFDictionary, &massStorageIterator) == KERN_SUCCESS else { return nil }
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, massStorageMatcher as CFDictionary, &massStorageIterator) == KERN_SUCCESS else { return nil }
 
         repeat {
             let media = IOIteratorNext(massStorageIterator)

--- a/macos/QMK Toolbox/USB/USBListener.swift
+++ b/macos/QMK Toolbox/USB/USBListener.swift
@@ -25,7 +25,7 @@ class USBListener: BootloaderDeviceDelegate {
     }
 
     func start() {
-        notificationPort = IONotificationPortCreate(kIOMasterPortDefault)
+        notificationPort = IONotificationPortCreate(kIOMainPortDefault)
         let runLoopSource = IONotificationPortGetRunLoopSource(notificationPort).takeUnretainedValue()
         CFRunLoopAddSource(RunLoop.current.getCFRunLoop(), runLoopSource, .defaultMode)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Opening files via double-click stopped working. Removing the NSDocumentClass value from the document types seems to fix it.
* `NSOpenPanel.allowedFileTypes` is deprecated as of macOS 12 - replace with `.allowedContentTypes`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
