### PR TITLE
[Windows] Fix positioning for key tester and HID console windows

### DIFF
--- a/windows/QMK Toolbox/HidConsole/HidConsoleWindow.Designer.cs
+++ b/windows/QMK Toolbox/HidConsole/HidConsoleWindow.Designer.cs
@@ -28,139 +28,141 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
+            Properties.Settings settings1 = new Properties.Settings();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HidConsoleWindow));
-            this.consoleList = new QMK_Toolbox.ComboBoxPlaceholder();
-            this.logTextBox = new QMK_Toolbox.LogTextBox();
-            this.logContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.logContextMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
-            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
-            this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.logContextMenu.SuspendLayout();
-            this.SuspendLayout();
+            consoleList = new ComboBoxPlaceholder();
+            logTextBox = new LogTextBox();
+            logContextMenu = new System.Windows.Forms.ContextMenuStrip(components);
+            cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            logContextMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
+            selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
+            clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            logContextMenu.SuspendLayout();
+            SuspendLayout();
             // 
             // consoleList
             // 
-            this.consoleList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.consoleList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.consoleList.FormattingEnabled = true;
-            this.consoleList.Location = new System.Drawing.Point(12, 12);
-            this.consoleList.Name = "consoleList";
-            this.consoleList.PlaceholderText = "No HID console devices connected";
-            this.consoleList.Size = new System.Drawing.Size(600, 21);
-            this.consoleList.TabIndex = 0;
+            consoleList.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            consoleList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            consoleList.FormattingEnabled = true;
+            consoleList.Location = new System.Drawing.Point(14, 14);
+            consoleList.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            consoleList.Name = "consoleList";
+            consoleList.PlaceholderText = "No HID console devices connected";
+            consoleList.Size = new System.Drawing.Size(699, 23);
+            consoleList.TabIndex = 0;
             // 
             // logTextBox
             // 
-            this.logTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.logTextBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
-            this.logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.logTextBox.ContextMenuStrip = this.logContextMenu;
-            this.logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", global::QMK_Toolbox.Properties.Settings.Default, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.logTextBox.DetectUrls = false;
-            this.logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.logTextBox.ForeColor = System.Drawing.Color.White;
-            this.logTextBox.HideSelection = false;
-            this.logTextBox.Location = new System.Drawing.Point(12, 39);
-            this.logTextBox.Name = "logTextBox";
-            this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(600, 390);
-            this.logTextBox.TabIndex = 1;
-            this.logTextBox.Text = "";
-            this.logTextBox.WordWrap = false;
-            this.logTextBox.ZoomFactor = global::QMK_Toolbox.Properties.Settings.Default.outputZoom;
+            logTextBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            logTextBox.BackColor = System.Drawing.Color.FromArgb(30, 30, 30);
+            logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            logTextBox.ContextMenuStrip = logContextMenu;
+            settings1.autoSetting = false;
+            settings1.driversInstalled = false;
+            settings1.firstStart = true;
+            settings1.hexFileCollection = null;
+            settings1.hexFileSetting = "";
+            settings1.keyboard = "";
+            settings1.keymap = "";
+            settings1.outputZoom = 1F;
+            settings1.SettingsKey = "";
+            settings1.showAllDevices = false;
+            settings1.targetSetting = "atmega32u4";
+            logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", settings1, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            logTextBox.DetectUrls = false;
+            logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            logTextBox.ForeColor = System.Drawing.Color.White;
+            logTextBox.HideSelection = false;
+            logTextBox.Location = new System.Drawing.Point(14, 45);
+            logTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            logTextBox.Name = "logTextBox";
+            logTextBox.ReadOnly = true;
+            logTextBox.Size = new System.Drawing.Size(700, 450);
+            logTextBox.TabIndex = 1;
+            logTextBox.Text = "";
+            logTextBox.WordWrap = false;
             // 
             // logContextMenu
             // 
-            this.logContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cutToolStripMenuItem,
-            this.copyToolStripMenuItem,
-            this.pasteToolStripMenuItem,
-            this.logContextMenuSep1,
-            this.selectAllToolStripMenuItem,
-            this.logContextMenuSep2,
-            this.clearToolStripMenuItem});
-            this.logContextMenu.Name = "contextMenuStrip2";
-            this.logContextMenu.ShowImageMargin = false;
-            this.logContextMenu.Size = new System.Drawing.Size(140, 126);
+            logContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { cutToolStripMenuItem, copyToolStripMenuItem, pasteToolStripMenuItem, logContextMenuSep1, selectAllToolStripMenuItem, logContextMenuSep2, clearToolStripMenuItem });
+            logContextMenu.Name = "contextMenuStrip2";
+            logContextMenu.ShowImageMargin = false;
+            logContextMenu.Size = new System.Drawing.Size(140, 126);
             // 
             // cutToolStripMenuItem
             // 
-            this.cutToolStripMenuItem.Enabled = false;
-            this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
-            this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.cutToolStripMenuItem.Text = "Cut";
+            cutToolStripMenuItem.Enabled = false;
+            cutToolStripMenuItem.Name = "cutToolStripMenuItem";
+            cutToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X;
+            cutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            cutToolStripMenuItem.Text = "Cut";
             // 
             // copyToolStripMenuItem
             // 
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.copyToolStripMenuItem.Text = "&Copy";
+            copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            copyToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C;
+            copyToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            copyToolStripMenuItem.Text = "&Copy";
             // 
             // pasteToolStripMenuItem
             // 
-            this.pasteToolStripMenuItem.Enabled = false;
-            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.pasteToolStripMenuItem.Text = "Paste";
+            pasteToolStripMenuItem.Enabled = false;
+            pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            pasteToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V;
+            pasteToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            pasteToolStripMenuItem.Text = "Paste";
             // 
             // logContextMenuSep1
             // 
-            this.logContextMenuSep1.Name = "logContextMenuSep1";
-            this.logContextMenuSep1.Size = new System.Drawing.Size(136, 6);
+            logContextMenuSep1.Name = "logContextMenuSep1";
+            logContextMenuSep1.Size = new System.Drawing.Size(136, 6);
             // 
             // selectAllToolStripMenuItem
             // 
-            this.selectAllToolStripMenuItem.Enabled = false;
-            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-            this.selectAllToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.selectAllToolStripMenuItem.Text = "Select &All";
+            selectAllToolStripMenuItem.Enabled = false;
+            selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            selectAllToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A;
+            selectAllToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            selectAllToolStripMenuItem.Text = "Select &All";
             // 
             // logContextMenuSep2
             // 
-            this.logContextMenuSep2.Name = "logContextMenuSep2";
-            this.logContextMenuSep2.Size = new System.Drawing.Size(136, 6);
+            logContextMenuSep2.Name = "logContextMenuSep2";
+            logContextMenuSep2.Size = new System.Drawing.Size(136, 6);
             // 
             // clearToolStripMenuItem
             // 
-            this.clearToolStripMenuItem.Enabled = false;
-            this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
-            this.clearToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.clearToolStripMenuItem.Text = "Clea&r";
-            this.clearToolStripMenuItem.Click += new System.EventHandler(this.ClearToolStripMenuItem_Click);
+            clearToolStripMenuItem.Enabled = false;
+            clearToolStripMenuItem.Name = "clearToolStripMenuItem";
+            clearToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            clearToolStripMenuItem.Text = "Clea&r";
+            clearToolStripMenuItem.Click += ClearToolStripMenuItem_Click;
             // 
             // HidConsoleWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(624, 441);
-            this.Controls.Add(this.consoleList);
-            this.Controls.Add(this.logTextBox);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(1024, 960);
-            this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(640, 480);
-            this.Name = "HidConsoleWindow";
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "HID Console";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.HidConsoleWindow_FormClosing);
-            this.Load += new System.EventHandler(this.HidConsoleWindow_Load);
-            this.logContextMenu.ResumeLayout(false);
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(728, 509);
+            Controls.Add(consoleList);
+            Controls.Add(logTextBox);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MaximumSize = new System.Drawing.Size(1192, 1102);
+            MinimizeBox = false;
+            MinimumSize = new System.Drawing.Size(744, 548);
+            Name = "HidConsoleWindow";
+            ShowInTaskbar = false;
+            Text = "HID Console";
+            FormClosing += HidConsoleWindow_FormClosing;
+            Load += HidConsoleWindow_Load;
+            logContextMenu.ResumeLayout(false);
+            ResumeLayout(false);
         }
 
         #endregion

--- a/windows/QMK Toolbox/HidConsole/HidConsoleWindow.cs
+++ b/windows/QMK Toolbox/HidConsole/HidConsoleWindow.cs
@@ -27,6 +27,8 @@ namespace QMK_Toolbox.HidConsole
 
         private void HidConsoleWindow_Load(object sender, EventArgs e)
         {
+            CenterToParent();
+
             consoleListener.consoleDeviceConnected += ConsoleDeviceConnected;
             consoleListener.consoleDeviceDisconnected += ConsoleDeviceDisconnected;
             consoleListener.consoleReportReceived += ConsoleReportReceived;

--- a/windows/QMK Toolbox/HidConsole/HidConsoleWindow.resx
+++ b/windows/QMK Toolbox/HidConsole/HidConsoleWindow.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/windows/QMK Toolbox/KeyTester/KeyControl.Designer.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyControl.Designer.cs
@@ -28,31 +28,31 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.lblLegend = new System.Windows.Forms.Label();
-            this.SuspendLayout();
+            lblLegend = new System.Windows.Forms.Label();
+            SuspendLayout();
             // 
             // lblLegend
             // 
-            this.lblLegend.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.lblLegend.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.lblLegend.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblLegend.Location = new System.Drawing.Point(0, 0);
-            this.lblLegend.Margin = new System.Windows.Forms.Padding(0);
-            this.lblLegend.Name = "lblLegend";
-            this.lblLegend.Size = new System.Drawing.Size(40, 40);
-            this.lblLegend.TabIndex = 0;
-            this.lblLegend.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            lblLegend.BackColor = System.Drawing.SystemColors.ControlLight;
+            lblLegend.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            lblLegend.Dock = System.Windows.Forms.DockStyle.Fill;
+            lblLegend.Location = new System.Drawing.Point(0, 0);
+            lblLegend.Margin = new System.Windows.Forms.Padding(0);
+            lblLegend.Name = "lblLegend";
+            lblLegend.Size = new System.Drawing.Size(47, 46);
+            lblLegend.TabIndex = 0;
+            lblLegend.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // KeyControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.lblLegend);
-            this.Enabled = false;
-            this.Name = "KeyControl";
-            this.Size = new System.Drawing.Size(40, 40);
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(lblLegend);
+            Enabled = false;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "KeyControl";
+            Size = new System.Drawing.Size(47, 46);
+            ResumeLayout(false);
         }
 
         #endregion

--- a/windows/QMK Toolbox/KeyTester/KeyControl.resx
+++ b/windows/QMK Toolbox/KeyTester/KeyControl.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
@@ -182,7 +182,7 @@
             keyF1.Enabled = false;
             keyF1.Legend = "F1";
             keyF1.Location = new System.Drawing.Point(127, 70);
-            keyF1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF1.Margin = new System.Windows.Forms.Padding(5);
             keyF1.Name = "keyF1";
             keyF1.Pressed = false;
             keyF1.Size = new System.Drawing.Size(47, 46);
@@ -194,7 +194,7 @@
             keyF2.Enabled = false;
             keyF2.Legend = "F2";
             keyF2.Location = new System.Drawing.Point(183, 70);
-            keyF2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF2.Margin = new System.Windows.Forms.Padding(5);
             keyF2.Name = "keyF2";
             keyF2.Pressed = false;
             keyF2.Size = new System.Drawing.Size(47, 46);
@@ -206,7 +206,7 @@
             keyF3.Enabled = false;
             keyF3.Legend = "F3";
             keyF3.Location = new System.Drawing.Point(239, 70);
-            keyF3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF3.Margin = new System.Windows.Forms.Padding(5);
             keyF3.Name = "keyF3";
             keyF3.Pressed = false;
             keyF3.Size = new System.Drawing.Size(47, 46);
@@ -218,7 +218,7 @@
             keyF4.Enabled = false;
             keyF4.Legend = "F4";
             keyF4.Location = new System.Drawing.Point(295, 70);
-            keyF4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF4.Margin = new System.Windows.Forms.Padding(5);
             keyF4.Name = "keyF4";
             keyF4.Pressed = false;
             keyF4.Size = new System.Drawing.Size(47, 46);
@@ -230,7 +230,7 @@
             keyF5.Enabled = false;
             keyF5.Legend = "F5";
             keyF5.Location = new System.Drawing.Point(379, 70);
-            keyF5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF5.Margin = new System.Windows.Forms.Padding(5);
             keyF5.Name = "keyF5";
             keyF5.Pressed = false;
             keyF5.Size = new System.Drawing.Size(47, 46);
@@ -242,7 +242,7 @@
             keyF6.Enabled = false;
             keyF6.Legend = "F6";
             keyF6.Location = new System.Drawing.Point(435, 70);
-            keyF6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF6.Margin = new System.Windows.Forms.Padding(5);
             keyF6.Name = "keyF6";
             keyF6.Pressed = false;
             keyF6.Size = new System.Drawing.Size(47, 46);
@@ -254,7 +254,7 @@
             keyF7.Enabled = false;
             keyF7.Legend = "F7";
             keyF7.Location = new System.Drawing.Point(491, 70);
-            keyF7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF7.Margin = new System.Windows.Forms.Padding(5);
             keyF7.Name = "keyF7";
             keyF7.Pressed = false;
             keyF7.Size = new System.Drawing.Size(47, 46);
@@ -266,7 +266,7 @@
             keyF8.Enabled = false;
             keyF8.Legend = "F8";
             keyF8.Location = new System.Drawing.Point(547, 70);
-            keyF8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF8.Margin = new System.Windows.Forms.Padding(5);
             keyF8.Name = "keyF8";
             keyF8.Pressed = false;
             keyF8.Size = new System.Drawing.Size(47, 46);
@@ -278,7 +278,7 @@
             keyF9.Enabled = false;
             keyF9.Legend = "F9";
             keyF9.Location = new System.Drawing.Point(631, 70);
-            keyF9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF9.Margin = new System.Windows.Forms.Padding(5);
             keyF9.Name = "keyF9";
             keyF9.Pressed = false;
             keyF9.Size = new System.Drawing.Size(47, 46);
@@ -290,7 +290,7 @@
             keyF10.Enabled = false;
             keyF10.Legend = "F10";
             keyF10.Location = new System.Drawing.Point(687, 70);
-            keyF10.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF10.Margin = new System.Windows.Forms.Padding(5);
             keyF10.Name = "keyF10";
             keyF10.Pressed = false;
             keyF10.Size = new System.Drawing.Size(47, 46);
@@ -302,7 +302,7 @@
             keyF11.Enabled = false;
             keyF11.Legend = "F11";
             keyF11.Location = new System.Drawing.Point(743, 70);
-            keyF11.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF11.Margin = new System.Windows.Forms.Padding(5);
             keyF11.Name = "keyF11";
             keyF11.Pressed = false;
             keyF11.Size = new System.Drawing.Size(47, 46);
@@ -314,7 +314,7 @@
             keyF12.Enabled = false;
             keyF12.Legend = "F12";
             keyF12.Location = new System.Drawing.Point(799, 70);
-            keyF12.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF12.Margin = new System.Windows.Forms.Padding(5);
             keyF12.Name = "keyF12";
             keyF12.Pressed = false;
             keyF12.Size = new System.Drawing.Size(47, 46);
@@ -326,7 +326,7 @@
             keyF13.Enabled = false;
             keyF13.Legend = "F13";
             keyF13.Location = new System.Drawing.Point(127, 15);
-            keyF13.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF13.Margin = new System.Windows.Forms.Padding(5);
             keyF13.Name = "keyF13";
             keyF13.Pressed = false;
             keyF13.Size = new System.Drawing.Size(47, 46);
@@ -338,7 +338,7 @@
             keyF14.Enabled = false;
             keyF14.Legend = "F14";
             keyF14.Location = new System.Drawing.Point(183, 15);
-            keyF14.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF14.Margin = new System.Windows.Forms.Padding(5);
             keyF14.Name = "keyF14";
             keyF14.Pressed = false;
             keyF14.Size = new System.Drawing.Size(47, 46);
@@ -350,7 +350,7 @@
             keyF15.Enabled = false;
             keyF15.Legend = "F15";
             keyF15.Location = new System.Drawing.Point(239, 15);
-            keyF15.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF15.Margin = new System.Windows.Forms.Padding(5);
             keyF15.Name = "keyF15";
             keyF15.Pressed = false;
             keyF15.Size = new System.Drawing.Size(47, 46);
@@ -362,7 +362,7 @@
             keyF16.Enabled = false;
             keyF16.Legend = "F16";
             keyF16.Location = new System.Drawing.Point(295, 15);
-            keyF16.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF16.Margin = new System.Windows.Forms.Padding(5);
             keyF16.Name = "keyF16";
             keyF16.Pressed = false;
             keyF16.Size = new System.Drawing.Size(47, 46);
@@ -374,7 +374,7 @@
             keyF17.Enabled = false;
             keyF17.Legend = "F17";
             keyF17.Location = new System.Drawing.Point(379, 15);
-            keyF17.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF17.Margin = new System.Windows.Forms.Padding(5);
             keyF17.Name = "keyF17";
             keyF17.Pressed = false;
             keyF17.Size = new System.Drawing.Size(47, 46);
@@ -386,7 +386,7 @@
             keyF18.Enabled = false;
             keyF18.Legend = "F18";
             keyF18.Location = new System.Drawing.Point(435, 15);
-            keyF18.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF18.Margin = new System.Windows.Forms.Padding(5);
             keyF18.Name = "keyF18";
             keyF18.Pressed = false;
             keyF18.Size = new System.Drawing.Size(47, 46);
@@ -398,7 +398,7 @@
             keyF19.Enabled = false;
             keyF19.Legend = "F19";
             keyF19.Location = new System.Drawing.Point(491, 15);
-            keyF19.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF19.Margin = new System.Windows.Forms.Padding(5);
             keyF19.Name = "keyF19";
             keyF19.Pressed = false;
             keyF19.Size = new System.Drawing.Size(47, 46);
@@ -410,7 +410,7 @@
             keyF20.Enabled = false;
             keyF20.Legend = "F20";
             keyF20.Location = new System.Drawing.Point(547, 15);
-            keyF20.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF20.Margin = new System.Windows.Forms.Padding(5);
             keyF20.Name = "keyF20";
             keyF20.Pressed = false;
             keyF20.Size = new System.Drawing.Size(47, 46);
@@ -422,7 +422,7 @@
             keyF21.Enabled = false;
             keyF21.Legend = "F21";
             keyF21.Location = new System.Drawing.Point(631, 15);
-            keyF21.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF21.Margin = new System.Windows.Forms.Padding(5);
             keyF21.Name = "keyF21";
             keyF21.Pressed = false;
             keyF21.Size = new System.Drawing.Size(47, 46);
@@ -434,7 +434,7 @@
             keyF22.Enabled = false;
             keyF22.Legend = "F22";
             keyF22.Location = new System.Drawing.Point(687, 15);
-            keyF22.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF22.Margin = new System.Windows.Forms.Padding(5);
             keyF22.Name = "keyF22";
             keyF22.Pressed = false;
             keyF22.Size = new System.Drawing.Size(47, 46);
@@ -446,7 +446,7 @@
             keyF23.Enabled = false;
             keyF23.Legend = "F23";
             keyF23.Location = new System.Drawing.Point(743, 15);
-            keyF23.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF23.Margin = new System.Windows.Forms.Padding(5);
             keyF23.Name = "keyF23";
             keyF23.Pressed = false;
             keyF23.Size = new System.Drawing.Size(47, 46);
@@ -458,7 +458,7 @@
             keyF24.Enabled = false;
             keyF24.Legend = "F24";
             keyF24.Location = new System.Drawing.Point(799, 15);
-            keyF24.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF24.Margin = new System.Windows.Forms.Padding(5);
             keyF24.Name = "keyF24";
             keyF24.Pressed = false;
             keyF24.Size = new System.Drawing.Size(47, 46);
@@ -470,7 +470,7 @@
             key1.Enabled = false;
             key1.Legend = "!\r\n1";
             key1.Location = new System.Drawing.Point(71, 144);
-            key1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key1.Margin = new System.Windows.Forms.Padding(5);
             key1.Name = "key1";
             key1.Pressed = false;
             key1.Size = new System.Drawing.Size(47, 46);
@@ -482,7 +482,7 @@
             key2.Enabled = false;
             key2.Legend = "@\r\n2";
             key2.Location = new System.Drawing.Point(127, 144);
-            key2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key2.Margin = new System.Windows.Forms.Padding(5);
             key2.Name = "key2";
             key2.Pressed = false;
             key2.Size = new System.Drawing.Size(47, 46);
@@ -494,7 +494,7 @@
             key3.Enabled = false;
             key3.Legend = "#\r\n3";
             key3.Location = new System.Drawing.Point(183, 144);
-            key3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key3.Margin = new System.Windows.Forms.Padding(5);
             key3.Name = "key3";
             key3.Pressed = false;
             key3.Size = new System.Drawing.Size(47, 46);
@@ -506,7 +506,7 @@
             key4.Enabled = false;
             key4.Legend = "$\r\n4";
             key4.Location = new System.Drawing.Point(239, 144);
-            key4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key4.Margin = new System.Windows.Forms.Padding(5);
             key4.Name = "key4";
             key4.Pressed = false;
             key4.Size = new System.Drawing.Size(47, 46);
@@ -518,7 +518,7 @@
             key5.Enabled = false;
             key5.Legend = "%\r\n5";
             key5.Location = new System.Drawing.Point(295, 144);
-            key5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key5.Margin = new System.Windows.Forms.Padding(5);
             key5.Name = "key5";
             key5.Pressed = false;
             key5.Size = new System.Drawing.Size(47, 46);
@@ -530,7 +530,7 @@
             key6.Enabled = false;
             key6.Legend = "^\r\n6";
             key6.Location = new System.Drawing.Point(351, 144);
-            key6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key6.Margin = new System.Windows.Forms.Padding(5);
             key6.Name = "key6";
             key6.Pressed = false;
             key6.Size = new System.Drawing.Size(47, 46);
@@ -542,7 +542,7 @@
             key7.Enabled = false;
             key7.Legend = "&&\r\n7";
             key7.Location = new System.Drawing.Point(407, 144);
-            key7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key7.Margin = new System.Windows.Forms.Padding(5);
             key7.Name = "key7";
             key7.Pressed = false;
             key7.Size = new System.Drawing.Size(47, 46);
@@ -554,7 +554,7 @@
             key8.Enabled = false;
             key8.Legend = "*\r\n8";
             key8.Location = new System.Drawing.Point(463, 144);
-            key8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key8.Margin = new System.Windows.Forms.Padding(5);
             key8.Name = "key8";
             key8.Pressed = false;
             key8.Size = new System.Drawing.Size(47, 46);
@@ -566,7 +566,7 @@
             key9.Enabled = false;
             key9.Legend = "(\r\n9";
             key9.Location = new System.Drawing.Point(519, 144);
-            key9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key9.Margin = new System.Windows.Forms.Padding(5);
             key9.Name = "key9";
             key9.Pressed = false;
             key9.Size = new System.Drawing.Size(47, 46);
@@ -578,7 +578,7 @@
             key0.Enabled = false;
             key0.Legend = ")\r\n0";
             key0.Location = new System.Drawing.Point(575, 144);
-            key0.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key0.Margin = new System.Windows.Forms.Padding(5);
             key0.Name = "key0";
             key0.Pressed = false;
             key0.Size = new System.Drawing.Size(47, 46);
@@ -590,7 +590,7 @@
             keyQ.Enabled = false;
             keyQ.Legend = "Q";
             keyQ.Location = new System.Drawing.Point(99, 200);
-            keyQ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyQ.Margin = new System.Windows.Forms.Padding(5);
             keyQ.Name = "keyQ";
             keyQ.Pressed = false;
             keyQ.Size = new System.Drawing.Size(47, 46);
@@ -602,7 +602,7 @@
             keyW.Enabled = false;
             keyW.Legend = "W";
             keyW.Location = new System.Drawing.Point(155, 200);
-            keyW.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyW.Margin = new System.Windows.Forms.Padding(5);
             keyW.Name = "keyW";
             keyW.Pressed = false;
             keyW.Size = new System.Drawing.Size(47, 46);
@@ -614,7 +614,7 @@
             keyE.Enabled = false;
             keyE.Legend = "E";
             keyE.Location = new System.Drawing.Point(211, 200);
-            keyE.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyE.Margin = new System.Windows.Forms.Padding(5);
             keyE.Name = "keyE";
             keyE.Pressed = false;
             keyE.Size = new System.Drawing.Size(47, 46);
@@ -626,7 +626,7 @@
             keyR.Enabled = false;
             keyR.Legend = "R";
             keyR.Location = new System.Drawing.Point(267, 200);
-            keyR.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyR.Margin = new System.Windows.Forms.Padding(5);
             keyR.Name = "keyR";
             keyR.Pressed = false;
             keyR.Size = new System.Drawing.Size(47, 46);
@@ -638,7 +638,7 @@
             keyT.Enabled = false;
             keyT.Legend = "T";
             keyT.Location = new System.Drawing.Point(323, 200);
-            keyT.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyT.Margin = new System.Windows.Forms.Padding(5);
             keyT.Name = "keyT";
             keyT.Pressed = false;
             keyT.Size = new System.Drawing.Size(47, 46);
@@ -650,7 +650,7 @@
             keyY.Enabled = false;
             keyY.Legend = "Y";
             keyY.Location = new System.Drawing.Point(379, 200);
-            keyY.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyY.Margin = new System.Windows.Forms.Padding(5);
             keyY.Name = "keyY";
             keyY.Pressed = false;
             keyY.Size = new System.Drawing.Size(47, 46);
@@ -662,7 +662,7 @@
             keyU.Enabled = false;
             keyU.Legend = "U";
             keyU.Location = new System.Drawing.Point(435, 200);
-            keyU.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyU.Margin = new System.Windows.Forms.Padding(5);
             keyU.Name = "keyU";
             keyU.Pressed = false;
             keyU.Size = new System.Drawing.Size(47, 46);
@@ -674,7 +674,7 @@
             keyI.Enabled = false;
             keyI.Legend = "I";
             keyI.Location = new System.Drawing.Point(491, 200);
-            keyI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyI.Margin = new System.Windows.Forms.Padding(5);
             keyI.Name = "keyI";
             keyI.Pressed = false;
             keyI.Size = new System.Drawing.Size(47, 46);
@@ -686,7 +686,7 @@
             keyO.Enabled = false;
             keyO.Legend = "O";
             keyO.Location = new System.Drawing.Point(547, 200);
-            keyO.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyO.Margin = new System.Windows.Forms.Padding(5);
             keyO.Name = "keyO";
             keyO.Pressed = false;
             keyO.Size = new System.Drawing.Size(47, 46);
@@ -698,7 +698,7 @@
             keyP.Enabled = false;
             keyP.Legend = "P";
             keyP.Location = new System.Drawing.Point(603, 200);
-            keyP.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyP.Margin = new System.Windows.Forms.Padding(5);
             keyP.Name = "keyP";
             keyP.Pressed = false;
             keyP.Size = new System.Drawing.Size(47, 46);
@@ -710,7 +710,7 @@
             keyA.Enabled = false;
             keyA.Legend = "A";
             keyA.Location = new System.Drawing.Point(113, 255);
-            keyA.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyA.Margin = new System.Windows.Forms.Padding(5);
             keyA.Name = "keyA";
             keyA.Pressed = false;
             keyA.Size = new System.Drawing.Size(47, 46);
@@ -722,7 +722,7 @@
             keyS.Enabled = false;
             keyS.Legend = "S";
             keyS.Location = new System.Drawing.Point(169, 255);
-            keyS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyS.Margin = new System.Windows.Forms.Padding(5);
             keyS.Name = "keyS";
             keyS.Pressed = false;
             keyS.Size = new System.Drawing.Size(47, 46);
@@ -734,7 +734,7 @@
             keyD.Enabled = false;
             keyD.Legend = "D";
             keyD.Location = new System.Drawing.Point(225, 255);
-            keyD.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyD.Margin = new System.Windows.Forms.Padding(5);
             keyD.Name = "keyD";
             keyD.Pressed = false;
             keyD.Size = new System.Drawing.Size(47, 46);
@@ -746,7 +746,7 @@
             keyF.Enabled = false;
             keyF.Legend = "F";
             keyF.Location = new System.Drawing.Point(281, 255);
-            keyF.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF.Margin = new System.Windows.Forms.Padding(5);
             keyF.Name = "keyF";
             keyF.Pressed = false;
             keyF.Size = new System.Drawing.Size(47, 46);
@@ -758,7 +758,7 @@
             keyG.Enabled = false;
             keyG.Legend = "G";
             keyG.Location = new System.Drawing.Point(337, 255);
-            keyG.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyG.Margin = new System.Windows.Forms.Padding(5);
             keyG.Name = "keyG";
             keyG.Pressed = false;
             keyG.Size = new System.Drawing.Size(47, 46);
@@ -770,7 +770,7 @@
             keyH.Enabled = false;
             keyH.Legend = "H";
             keyH.Location = new System.Drawing.Point(393, 255);
-            keyH.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyH.Margin = new System.Windows.Forms.Padding(5);
             keyH.Name = "keyH";
             keyH.Pressed = false;
             keyH.Size = new System.Drawing.Size(47, 46);
@@ -782,7 +782,7 @@
             keyJ.Enabled = false;
             keyJ.Legend = "J";
             keyJ.Location = new System.Drawing.Point(449, 255);
-            keyJ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyJ.Margin = new System.Windows.Forms.Padding(5);
             keyJ.Name = "keyJ";
             keyJ.Pressed = false;
             keyJ.Size = new System.Drawing.Size(47, 46);
@@ -794,7 +794,7 @@
             keyK.Enabled = false;
             keyK.Legend = "K";
             keyK.Location = new System.Drawing.Point(505, 255);
-            keyK.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyK.Margin = new System.Windows.Forms.Padding(5);
             keyK.Name = "keyK";
             keyK.Pressed = false;
             keyK.Size = new System.Drawing.Size(47, 46);
@@ -806,7 +806,7 @@
             keyL.Enabled = false;
             keyL.Legend = "L";
             keyL.Location = new System.Drawing.Point(561, 255);
-            keyL.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyL.Margin = new System.Windows.Forms.Padding(5);
             keyL.Name = "keyL";
             keyL.Pressed = false;
             keyL.Size = new System.Drawing.Size(47, 46);
@@ -818,7 +818,7 @@
             keyZ.Enabled = false;
             keyZ.Legend = "Z";
             keyZ.Location = new System.Drawing.Point(141, 310);
-            keyZ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyZ.Margin = new System.Windows.Forms.Padding(5);
             keyZ.Name = "keyZ";
             keyZ.Pressed = false;
             keyZ.Size = new System.Drawing.Size(47, 46);
@@ -830,7 +830,7 @@
             keyX.Enabled = false;
             keyX.Legend = "X";
             keyX.Location = new System.Drawing.Point(197, 310);
-            keyX.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyX.Margin = new System.Windows.Forms.Padding(5);
             keyX.Name = "keyX";
             keyX.Pressed = false;
             keyX.Size = new System.Drawing.Size(47, 46);
@@ -842,7 +842,7 @@
             keyC.Enabled = false;
             keyC.Legend = "C";
             keyC.Location = new System.Drawing.Point(253, 310);
-            keyC.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyC.Margin = new System.Windows.Forms.Padding(5);
             keyC.Name = "keyC";
             keyC.Pressed = false;
             keyC.Size = new System.Drawing.Size(47, 46);
@@ -854,7 +854,7 @@
             keyV.Enabled = false;
             keyV.Legend = "V";
             keyV.Location = new System.Drawing.Point(309, 310);
-            keyV.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyV.Margin = new System.Windows.Forms.Padding(5);
             keyV.Name = "keyV";
             keyV.Pressed = false;
             keyV.Size = new System.Drawing.Size(47, 46);
@@ -866,7 +866,7 @@
             keyB.Enabled = false;
             keyB.Legend = "B";
             keyB.Location = new System.Drawing.Point(365, 310);
-            keyB.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyB.Margin = new System.Windows.Forms.Padding(5);
             keyB.Name = "keyB";
             keyB.Pressed = false;
             keyB.Size = new System.Drawing.Size(47, 46);
@@ -878,7 +878,7 @@
             keyN.Enabled = false;
             keyN.Legend = "N";
             keyN.Location = new System.Drawing.Point(421, 310);
-            keyN.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyN.Margin = new System.Windows.Forms.Padding(5);
             keyN.Name = "keyN";
             keyN.Pressed = false;
             keyN.Size = new System.Drawing.Size(47, 46);
@@ -890,7 +890,7 @@
             keyM.Enabled = false;
             keyM.Legend = "M";
             keyM.Location = new System.Drawing.Point(477, 310);
-            keyM.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyM.Margin = new System.Windows.Forms.Padding(5);
             keyM.Name = "keyM";
             keyM.Pressed = false;
             keyM.Size = new System.Drawing.Size(47, 46);
@@ -902,7 +902,7 @@
             keyEscape.Enabled = false;
             keyEscape.Legend = "Esc";
             keyEscape.Location = new System.Drawing.Point(15, 70);
-            keyEscape.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEscape.Margin = new System.Windows.Forms.Padding(5);
             keyEscape.Name = "keyEscape";
             keyEscape.Pressed = false;
             keyEscape.Size = new System.Drawing.Size(47, 46);
@@ -914,7 +914,7 @@
             keyGrave.Enabled = false;
             keyGrave.Legend = "~\r\n`";
             keyGrave.Location = new System.Drawing.Point(15, 144);
-            keyGrave.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyGrave.Margin = new System.Windows.Forms.Padding(5);
             keyGrave.Name = "keyGrave";
             keyGrave.Pressed = false;
             keyGrave.Size = new System.Drawing.Size(47, 46);
@@ -926,7 +926,7 @@
             keyMinus.Enabled = false;
             keyMinus.Legend = "_\r\n-";
             keyMinus.Location = new System.Drawing.Point(631, 144);
-            keyMinus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMinus.Margin = new System.Windows.Forms.Padding(5);
             keyMinus.Name = "keyMinus";
             keyMinus.Pressed = false;
             keyMinus.Size = new System.Drawing.Size(47, 46);
@@ -938,7 +938,7 @@
             keyEqual.Enabled = false;
             keyEqual.Legend = "+\r\n=";
             keyEqual.Location = new System.Drawing.Point(687, 144);
-            keyEqual.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEqual.Margin = new System.Windows.Forms.Padding(5);
             keyEqual.Name = "keyEqual";
             keyEqual.Pressed = false;
             keyEqual.Size = new System.Drawing.Size(47, 46);
@@ -950,7 +950,7 @@
             keyBackspace.Enabled = false;
             keyBackspace.Legend = "Backspace";
             keyBackspace.Location = new System.Drawing.Point(743, 144);
-            keyBackspace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyBackspace.Margin = new System.Windows.Forms.Padding(5);
             keyBackspace.Name = "keyBackspace";
             keyBackspace.Pressed = false;
             keyBackspace.Size = new System.Drawing.Size(103, 46);
@@ -962,7 +962,7 @@
             keyTab.Enabled = false;
             keyTab.Legend = "Tab";
             keyTab.Location = new System.Drawing.Point(15, 200);
-            keyTab.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyTab.Margin = new System.Windows.Forms.Padding(5);
             keyTab.Name = "keyTab";
             keyTab.Pressed = false;
             keyTab.Size = new System.Drawing.Size(75, 46);
@@ -974,7 +974,7 @@
             keyLeftBrace.Enabled = false;
             keyLeftBrace.Legend = "{\r\n[";
             keyLeftBrace.Location = new System.Drawing.Point(659, 200);
-            keyLeftBrace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftBrace.Margin = new System.Windows.Forms.Padding(5);
             keyLeftBrace.Name = "keyLeftBrace";
             keyLeftBrace.Pressed = false;
             keyLeftBrace.Size = new System.Drawing.Size(47, 46);
@@ -986,7 +986,7 @@
             keyRightBrace.Enabled = false;
             keyRightBrace.Legend = "}\r\n]";
             keyRightBrace.Location = new System.Drawing.Point(715, 200);
-            keyRightBrace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightBrace.Margin = new System.Windows.Forms.Padding(5);
             keyRightBrace.Name = "keyRightBrace";
             keyRightBrace.Pressed = false;
             keyRightBrace.Size = new System.Drawing.Size(47, 46);
@@ -998,7 +998,7 @@
             keyBackslash.Enabled = false;
             keyBackslash.Legend = "|\r\n\\";
             keyBackslash.Location = new System.Drawing.Point(771, 200);
-            keyBackslash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyBackslash.Margin = new System.Windows.Forms.Padding(5);
             keyBackslash.Name = "keyBackslash";
             keyBackslash.Pressed = false;
             keyBackslash.Size = new System.Drawing.Size(75, 46);
@@ -1010,7 +1010,7 @@
             keyCapsLock.Enabled = false;
             keyCapsLock.Legend = "Caps Lock";
             keyCapsLock.Location = new System.Drawing.Point(15, 255);
-            keyCapsLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyCapsLock.Margin = new System.Windows.Forms.Padding(5);
             keyCapsLock.Name = "keyCapsLock";
             keyCapsLock.Pressed = false;
             keyCapsLock.Size = new System.Drawing.Size(89, 46);
@@ -1022,7 +1022,7 @@
             keySemicolon.Enabled = false;
             keySemicolon.Legend = ":\r\n;";
             keySemicolon.Location = new System.Drawing.Point(617, 255);
-            keySemicolon.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySemicolon.Margin = new System.Windows.Forms.Padding(5);
             keySemicolon.Name = "keySemicolon";
             keySemicolon.Pressed = false;
             keySemicolon.Size = new System.Drawing.Size(47, 46);
@@ -1034,7 +1034,7 @@
             keyQuote.Enabled = false;
             keyQuote.Legend = "\"\r\n'";
             keyQuote.Location = new System.Drawing.Point(673, 255);
-            keyQuote.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyQuote.Margin = new System.Windows.Forms.Padding(5);
             keyQuote.Name = "keyQuote";
             keyQuote.Pressed = false;
             keyQuote.Size = new System.Drawing.Size(47, 46);
@@ -1046,7 +1046,7 @@
             keyNUHS.Enabled = false;
             keyNUHS.Legend = "~\r\n#";
             keyNUHS.Location = new System.Drawing.Point(729, 255);
-            keyNUHS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNUHS.Margin = new System.Windows.Forms.Padding(5);
             keyNUHS.Name = "keyNUHS";
             keyNUHS.Pressed = false;
             keyNUHS.Size = new System.Drawing.Size(47, 46);
@@ -1058,7 +1058,7 @@
             keyEnter.Enabled = false;
             keyEnter.Legend = "Enter";
             keyEnter.Location = new System.Drawing.Point(785, 255);
-            keyEnter.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEnter.Margin = new System.Windows.Forms.Padding(5);
             keyEnter.Name = "keyEnter";
             keyEnter.Pressed = false;
             keyEnter.Size = new System.Drawing.Size(61, 46);
@@ -1070,7 +1070,7 @@
             keyNUBS.Enabled = false;
             keyNUBS.Legend = "|\r\n\\";
             keyNUBS.Location = new System.Drawing.Point(85, 310);
-            keyNUBS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNUBS.Margin = new System.Windows.Forms.Padding(5);
             keyNUBS.Name = "keyNUBS";
             keyNUBS.Pressed = false;
             keyNUBS.Size = new System.Drawing.Size(47, 46);
@@ -1082,7 +1082,7 @@
             keyComma.Enabled = false;
             keyComma.Legend = "<\r\n,";
             keyComma.Location = new System.Drawing.Point(533, 310);
-            keyComma.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyComma.Margin = new System.Windows.Forms.Padding(5);
             keyComma.Name = "keyComma";
             keyComma.Pressed = false;
             keyComma.Size = new System.Drawing.Size(47, 46);
@@ -1094,7 +1094,7 @@
             keyDot.Enabled = false;
             keyDot.Legend = ">\r\n.";
             keyDot.Location = new System.Drawing.Point(589, 310);
-            keyDot.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDot.Margin = new System.Windows.Forms.Padding(5);
             keyDot.Name = "keyDot";
             keyDot.Pressed = false;
             keyDot.Size = new System.Drawing.Size(47, 46);
@@ -1106,7 +1106,7 @@
             keySlash.Enabled = false;
             keySlash.Legend = "?\r\n/";
             keySlash.Location = new System.Drawing.Point(645, 310);
-            keySlash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySlash.Margin = new System.Windows.Forms.Padding(5);
             keySlash.Name = "keySlash";
             keySlash.Pressed = false;
             keySlash.Size = new System.Drawing.Size(47, 46);
@@ -1118,7 +1118,7 @@
             keySpace.Enabled = false;
             keySpace.Legend = "";
             keySpace.Location = new System.Drawing.Point(225, 366);
-            keySpace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySpace.Margin = new System.Windows.Forms.Padding(5);
             keySpace.Name = "keySpace";
             keySpace.Pressed = false;
             keySpace.Size = new System.Drawing.Size(341, 46);
@@ -1130,7 +1130,7 @@
             keyMenu.Enabled = false;
             keyMenu.Legend = "Menu";
             keyMenu.Location = new System.Drawing.Point(715, 366);
-            keyMenu.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMenu.Margin = new System.Windows.Forms.Padding(5);
             keyMenu.Name = "keyMenu";
             keyMenu.Pressed = false;
             keyMenu.Size = new System.Drawing.Size(61, 46);
@@ -1142,7 +1142,7 @@
             keyLeftControl.Enabled = false;
             keyLeftControl.Legend = "Ctrl";
             keyLeftControl.Location = new System.Drawing.Point(15, 366);
-            keyLeftControl.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftControl.Margin = new System.Windows.Forms.Padding(5);
             keyLeftControl.Name = "keyLeftControl";
             keyLeftControl.Pressed = false;
             keyLeftControl.Size = new System.Drawing.Size(61, 46);
@@ -1154,7 +1154,7 @@
             keyLeftShift.Enabled = false;
             keyLeftShift.Legend = "Shift";
             keyLeftShift.Location = new System.Drawing.Point(15, 310);
-            keyLeftShift.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftShift.Margin = new System.Windows.Forms.Padding(5);
             keyLeftShift.Name = "keyLeftShift";
             keyLeftShift.Pressed = false;
             keyLeftShift.Size = new System.Drawing.Size(61, 46);
@@ -1166,7 +1166,7 @@
             keyLeftAlt.Enabled = false;
             keyLeftAlt.Legend = "Alt";
             keyLeftAlt.Location = new System.Drawing.Point(155, 366);
-            keyLeftAlt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftAlt.Margin = new System.Windows.Forms.Padding(5);
             keyLeftAlt.Name = "keyLeftAlt";
             keyLeftAlt.Pressed = false;
             keyLeftAlt.Size = new System.Drawing.Size(61, 46);
@@ -1178,7 +1178,7 @@
             keyLeftGUI.Enabled = false;
             keyLeftGUI.Legend = "Win";
             keyLeftGUI.Location = new System.Drawing.Point(85, 366);
-            keyLeftGUI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftGUI.Margin = new System.Windows.Forms.Padding(5);
             keyLeftGUI.Name = "keyLeftGUI";
             keyLeftGUI.Pressed = false;
             keyLeftGUI.Size = new System.Drawing.Size(61, 46);
@@ -1190,7 +1190,7 @@
             keyRightControl.Enabled = false;
             keyRightControl.Legend = "Ctrl";
             keyRightControl.Location = new System.Drawing.Point(785, 366);
-            keyRightControl.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightControl.Margin = new System.Windows.Forms.Padding(5);
             keyRightControl.Name = "keyRightControl";
             keyRightControl.Pressed = false;
             keyRightControl.Size = new System.Drawing.Size(61, 46);
@@ -1202,7 +1202,7 @@
             keyRightShift.Enabled = false;
             keyRightShift.Legend = "Shift";
             keyRightShift.Location = new System.Drawing.Point(701, 310);
-            keyRightShift.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightShift.Margin = new System.Windows.Forms.Padding(5);
             keyRightShift.Name = "keyRightShift";
             keyRightShift.Pressed = false;
             keyRightShift.Size = new System.Drawing.Size(145, 46);
@@ -1214,7 +1214,7 @@
             keyRightAlt.Enabled = false;
             keyRightAlt.Legend = "Alt";
             keyRightAlt.Location = new System.Drawing.Point(575, 366);
-            keyRightAlt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightAlt.Margin = new System.Windows.Forms.Padding(5);
             keyRightAlt.Name = "keyRightAlt";
             keyRightAlt.Pressed = false;
             keyRightAlt.Size = new System.Drawing.Size(61, 46);
@@ -1226,7 +1226,7 @@
             keyRightGUI.Enabled = false;
             keyRightGUI.Legend = "Win";
             keyRightGUI.Location = new System.Drawing.Point(645, 366);
-            keyRightGUI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightGUI.Margin = new System.Windows.Forms.Padding(5);
             keyRightGUI.Name = "keyRightGUI";
             keyRightGUI.Pressed = false;
             keyRightGUI.Size = new System.Drawing.Size(61, 46);
@@ -1238,7 +1238,7 @@
             keyPrintScreen.Enabled = false;
             keyPrintScreen.Legend = "Print\r\nScrn";
             keyPrintScreen.Location = new System.Drawing.Point(864, 70);
-            keyPrintScreen.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPrintScreen.Margin = new System.Windows.Forms.Padding(5);
             keyPrintScreen.Name = "keyPrintScreen";
             keyPrintScreen.Pressed = false;
             keyPrintScreen.Size = new System.Drawing.Size(47, 46);
@@ -1250,7 +1250,7 @@
             keyScrollLock.Enabled = false;
             keyScrollLock.Legend = "Scroll\r\nLock";
             keyScrollLock.Location = new System.Drawing.Point(920, 70);
-            keyScrollLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyScrollLock.Margin = new System.Windows.Forms.Padding(5);
             keyScrollLock.Name = "keyScrollLock";
             keyScrollLock.Pressed = false;
             keyScrollLock.Size = new System.Drawing.Size(47, 46);
@@ -1262,7 +1262,7 @@
             keyPauseBreak.Enabled = false;
             keyPauseBreak.Legend = "Pause";
             keyPauseBreak.Location = new System.Drawing.Point(976, 70);
-            keyPauseBreak.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPauseBreak.Margin = new System.Windows.Forms.Padding(5);
             keyPauseBreak.Name = "keyPauseBreak";
             keyPauseBreak.Pressed = false;
             keyPauseBreak.Size = new System.Drawing.Size(47, 46);
@@ -1274,7 +1274,7 @@
             keyInsert.Enabled = false;
             keyInsert.Legend = "Insert";
             keyInsert.Location = new System.Drawing.Point(864, 144);
-            keyInsert.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyInsert.Margin = new System.Windows.Forms.Padding(5);
             keyInsert.Name = "keyInsert";
             keyInsert.Pressed = false;
             keyInsert.Size = new System.Drawing.Size(47, 46);
@@ -1286,7 +1286,7 @@
             keyHome.Enabled = false;
             keyHome.Legend = "Home";
             keyHome.Location = new System.Drawing.Point(920, 144);
-            keyHome.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyHome.Margin = new System.Windows.Forms.Padding(5);
             keyHome.Name = "keyHome";
             keyHome.Pressed = false;
             keyHome.Size = new System.Drawing.Size(47, 46);
@@ -1298,7 +1298,7 @@
             keyPageUp.Enabled = false;
             keyPageUp.Legend = "Page\r\nUp";
             keyPageUp.Location = new System.Drawing.Point(976, 144);
-            keyPageUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPageUp.Margin = new System.Windows.Forms.Padding(5);
             keyPageUp.Name = "keyPageUp";
             keyPageUp.Pressed = false;
             keyPageUp.Size = new System.Drawing.Size(47, 46);
@@ -1310,7 +1310,7 @@
             keyDelete.Enabled = false;
             keyDelete.Legend = "Delete";
             keyDelete.Location = new System.Drawing.Point(864, 200);
-            keyDelete.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDelete.Margin = new System.Windows.Forms.Padding(5);
             keyDelete.Name = "keyDelete";
             keyDelete.Pressed = false;
             keyDelete.Size = new System.Drawing.Size(47, 46);
@@ -1322,7 +1322,7 @@
             keyEnd.Enabled = false;
             keyEnd.Legend = "End";
             keyEnd.Location = new System.Drawing.Point(920, 200);
-            keyEnd.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEnd.Margin = new System.Windows.Forms.Padding(5);
             keyEnd.Name = "keyEnd";
             keyEnd.Pressed = false;
             keyEnd.Size = new System.Drawing.Size(47, 46);
@@ -1334,7 +1334,7 @@
             keyPageDown.Enabled = false;
             keyPageDown.Legend = "Page\r\nDown";
             keyPageDown.Location = new System.Drawing.Point(976, 200);
-            keyPageDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPageDown.Margin = new System.Windows.Forms.Padding(5);
             keyPageDown.Name = "keyPageDown";
             keyPageDown.Pressed = false;
             keyPageDown.Size = new System.Drawing.Size(47, 46);
@@ -1346,7 +1346,7 @@
             keyUp.Enabled = false;
             keyUp.Legend = "▴";
             keyUp.Location = new System.Drawing.Point(920, 310);
-            keyUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyUp.Margin = new System.Windows.Forms.Padding(5);
             keyUp.Name = "keyUp";
             keyUp.Pressed = false;
             keyUp.Size = new System.Drawing.Size(47, 46);
@@ -1358,7 +1358,7 @@
             keyLeft.Enabled = false;
             keyLeft.Legend = "◂";
             keyLeft.Location = new System.Drawing.Point(864, 366);
-            keyLeft.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeft.Margin = new System.Windows.Forms.Padding(5);
             keyLeft.Name = "keyLeft";
             keyLeft.Pressed = false;
             keyLeft.Size = new System.Drawing.Size(47, 46);
@@ -1370,7 +1370,7 @@
             keyDown.Enabled = false;
             keyDown.Legend = "▾";
             keyDown.Location = new System.Drawing.Point(920, 366);
-            keyDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDown.Margin = new System.Windows.Forms.Padding(5);
             keyDown.Name = "keyDown";
             keyDown.Pressed = false;
             keyDown.Size = new System.Drawing.Size(47, 46);
@@ -1382,7 +1382,7 @@
             keyRight.Enabled = false;
             keyRight.Legend = "▸";
             keyRight.Location = new System.Drawing.Point(976, 366);
-            keyRight.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRight.Margin = new System.Windows.Forms.Padding(5);
             keyRight.Name = "keyRight";
             keyRight.Pressed = false;
             keyRight.Size = new System.Drawing.Size(47, 46);
@@ -1394,7 +1394,7 @@
             keyNumLock.Enabled = false;
             keyNumLock.Legend = "Num\r\nLock";
             keyNumLock.Location = new System.Drawing.Point(1042, 144);
-            keyNumLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNumLock.Margin = new System.Windows.Forms.Padding(5);
             keyNumLock.Name = "keyNumLock";
             keyNumLock.Pressed = false;
             keyNumLock.Size = new System.Drawing.Size(47, 46);
@@ -1406,7 +1406,7 @@
             keyPadSlash.Enabled = false;
             keyPadSlash.Legend = "/";
             keyPadSlash.Location = new System.Drawing.Point(1098, 144);
-            keyPadSlash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadSlash.Margin = new System.Windows.Forms.Padding(5);
             keyPadSlash.Name = "keyPadSlash";
             keyPadSlash.Pressed = false;
             keyPadSlash.Size = new System.Drawing.Size(47, 46);
@@ -1418,7 +1418,7 @@
             keyPadAsterisk.Enabled = false;
             keyPadAsterisk.Legend = "*";
             keyPadAsterisk.Location = new System.Drawing.Point(1154, 144);
-            keyPadAsterisk.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadAsterisk.Margin = new System.Windows.Forms.Padding(5);
             keyPadAsterisk.Name = "keyPadAsterisk";
             keyPadAsterisk.Pressed = false;
             keyPadAsterisk.Size = new System.Drawing.Size(47, 46);
@@ -1430,7 +1430,7 @@
             keyPadMinus.Enabled = false;
             keyPadMinus.Legend = "-";
             keyPadMinus.Location = new System.Drawing.Point(1210, 144);
-            keyPadMinus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadMinus.Margin = new System.Windows.Forms.Padding(5);
             keyPadMinus.Name = "keyPadMinus";
             keyPadMinus.Pressed = false;
             keyPadMinus.Size = new System.Drawing.Size(47, 46);
@@ -1442,7 +1442,7 @@
             keyPadPlus.Enabled = false;
             keyPadPlus.Legend = "+";
             keyPadPlus.Location = new System.Drawing.Point(1210, 200);
-            keyPadPlus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadPlus.Margin = new System.Windows.Forms.Padding(5);
             keyPadPlus.Name = "keyPadPlus";
             keyPadPlus.Pressed = false;
             keyPadPlus.Size = new System.Drawing.Size(47, 102);
@@ -1454,7 +1454,7 @@
             keyPadEnter.Enabled = false;
             keyPadEnter.Legend = "Ent";
             keyPadEnter.Location = new System.Drawing.Point(1210, 310);
-            keyPadEnter.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadEnter.Margin = new System.Windows.Forms.Padding(5);
             keyPadEnter.Name = "keyPadEnter";
             keyPadEnter.Pressed = false;
             keyPadEnter.Size = new System.Drawing.Size(47, 102);
@@ -1466,7 +1466,7 @@
             keyPadDot.Enabled = false;
             keyPadDot.Legend = ".";
             keyPadDot.Location = new System.Drawing.Point(1154, 366);
-            keyPadDot.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadDot.Margin = new System.Windows.Forms.Padding(5);
             keyPadDot.Name = "keyPadDot";
             keyPadDot.Pressed = false;
             keyPadDot.Size = new System.Drawing.Size(47, 46);
@@ -1478,7 +1478,7 @@
             keyPad0.Enabled = false;
             keyPad0.Legend = "0";
             keyPad0.Location = new System.Drawing.Point(1042, 366);
-            keyPad0.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad0.Margin = new System.Windows.Forms.Padding(5);
             keyPad0.Name = "keyPad0";
             keyPad0.Pressed = false;
             keyPad0.Size = new System.Drawing.Size(103, 46);
@@ -1490,7 +1490,7 @@
             keyPad1.Enabled = false;
             keyPad1.Legend = "1";
             keyPad1.Location = new System.Drawing.Point(1042, 310);
-            keyPad1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad1.Margin = new System.Windows.Forms.Padding(5);
             keyPad1.Name = "keyPad1";
             keyPad1.Pressed = false;
             keyPad1.Size = new System.Drawing.Size(47, 46);
@@ -1502,7 +1502,7 @@
             keyPad2.Enabled = false;
             keyPad2.Legend = "2";
             keyPad2.Location = new System.Drawing.Point(1098, 310);
-            keyPad2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad2.Margin = new System.Windows.Forms.Padding(5);
             keyPad2.Name = "keyPad2";
             keyPad2.Pressed = false;
             keyPad2.Size = new System.Drawing.Size(47, 46);
@@ -1514,7 +1514,7 @@
             keyPad3.Enabled = false;
             keyPad3.Legend = "3";
             keyPad3.Location = new System.Drawing.Point(1154, 310);
-            keyPad3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad3.Margin = new System.Windows.Forms.Padding(5);
             keyPad3.Name = "keyPad3";
             keyPad3.Pressed = false;
             keyPad3.Size = new System.Drawing.Size(47, 46);
@@ -1526,7 +1526,7 @@
             keyPad4.Enabled = false;
             keyPad4.Legend = "4";
             keyPad4.Location = new System.Drawing.Point(1042, 255);
-            keyPad4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad4.Margin = new System.Windows.Forms.Padding(5);
             keyPad4.Name = "keyPad4";
             keyPad4.Pressed = false;
             keyPad4.Size = new System.Drawing.Size(47, 46);
@@ -1538,7 +1538,7 @@
             keyPad5.Enabled = false;
             keyPad5.Legend = "5";
             keyPad5.Location = new System.Drawing.Point(1098, 255);
-            keyPad5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad5.Margin = new System.Windows.Forms.Padding(5);
             keyPad5.Name = "keyPad5";
             keyPad5.Pressed = false;
             keyPad5.Size = new System.Drawing.Size(47, 46);
@@ -1550,7 +1550,7 @@
             keyPad6.Enabled = false;
             keyPad6.Legend = "6";
             keyPad6.Location = new System.Drawing.Point(1154, 255);
-            keyPad6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad6.Margin = new System.Windows.Forms.Padding(5);
             keyPad6.Name = "keyPad6";
             keyPad6.Pressed = false;
             keyPad6.Size = new System.Drawing.Size(47, 46);
@@ -1562,7 +1562,7 @@
             keyPad7.Enabled = false;
             keyPad7.Legend = "7";
             keyPad7.Location = new System.Drawing.Point(1042, 200);
-            keyPad7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad7.Margin = new System.Windows.Forms.Padding(5);
             keyPad7.Name = "keyPad7";
             keyPad7.Pressed = false;
             keyPad7.Size = new System.Drawing.Size(47, 46);
@@ -1574,7 +1574,7 @@
             keyPad8.Enabled = false;
             keyPad8.Legend = "8";
             keyPad8.Location = new System.Drawing.Point(1098, 200);
-            keyPad8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad8.Margin = new System.Windows.Forms.Padding(5);
             keyPad8.Name = "keyPad8";
             keyPad8.Pressed = false;
             keyPad8.Size = new System.Drawing.Size(47, 46);
@@ -1586,7 +1586,7 @@
             keyPad9.Enabled = false;
             keyPad9.Legend = "9";
             keyPad9.Location = new System.Drawing.Point(1154, 200);
-            keyPad9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad9.Margin = new System.Windows.Forms.Padding(5);
             keyPad9.Name = "keyPad9";
             keyPad9.Pressed = false;
             keyPad9.Size = new System.Drawing.Size(47, 46);
@@ -1598,7 +1598,7 @@
             keyMute.Enabled = false;
             keyMute.Legend = "Mut";
             keyMute.Location = new System.Drawing.Point(1042, 15);
-            keyMute.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMute.Margin = new System.Windows.Forms.Padding(5);
             keyMute.Name = "keyMute";
             keyMute.Pressed = false;
             keyMute.Size = new System.Drawing.Size(47, 46);
@@ -1610,7 +1610,7 @@
             keyVolumeDown.Enabled = false;
             keyVolumeDown.Legend = "Vol-";
             keyVolumeDown.Location = new System.Drawing.Point(1098, 15);
-            keyVolumeDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyVolumeDown.Margin = new System.Windows.Forms.Padding(5);
             keyVolumeDown.Name = "keyVolumeDown";
             keyVolumeDown.Pressed = false;
             keyVolumeDown.Size = new System.Drawing.Size(47, 46);
@@ -1622,7 +1622,7 @@
             keyVolumeUp.Enabled = false;
             keyVolumeUp.Legend = "Vol+";
             keyVolumeUp.Location = new System.Drawing.Point(1154, 15);
-            keyVolumeUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyVolumeUp.Margin = new System.Windows.Forms.Padding(5);
             keyVolumeUp.Name = "keyVolumeUp";
             keyVolumeUp.Pressed = false;
             keyVolumeUp.Size = new System.Drawing.Size(47, 46);
@@ -1634,7 +1634,7 @@
             keyPlayPause.Enabled = false;
             keyPlayPause.Legend = "Play";
             keyPlayPause.Location = new System.Drawing.Point(1042, 70);
-            keyPlayPause.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPlayPause.Margin = new System.Windows.Forms.Padding(5);
             keyPlayPause.Name = "keyPlayPause";
             keyPlayPause.Pressed = false;
             keyPlayPause.Size = new System.Drawing.Size(47, 46);
@@ -1646,7 +1646,7 @@
             keyMediaPrevious.Enabled = false;
             keyMediaPrevious.Legend = "Prev";
             keyMediaPrevious.Location = new System.Drawing.Point(1098, 70);
-            keyMediaPrevious.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMediaPrevious.Margin = new System.Windows.Forms.Padding(5);
             keyMediaPrevious.Name = "keyMediaPrevious";
             keyMediaPrevious.Pressed = false;
             keyMediaPrevious.Size = new System.Drawing.Size(47, 46);
@@ -1658,7 +1658,7 @@
             keyMediaNext.Enabled = false;
             keyMediaNext.Legend = "Next";
             keyMediaNext.Location = new System.Drawing.Point(1154, 70);
-            keyMediaNext.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMediaNext.Margin = new System.Windows.Forms.Padding(5);
             keyMediaNext.Name = "keyMediaNext";
             keyMediaNext.Pressed = false;
             keyMediaNext.Size = new System.Drawing.Size(47, 46);
@@ -1670,7 +1670,7 @@
             keyMail.Enabled = false;
             keyMail.Legend = "Mail";
             keyMail.Location = new System.Drawing.Point(1210, 15);
-            keyMail.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMail.Margin = new System.Windows.Forms.Padding(5);
             keyMail.Name = "keyMail";
             keyMail.Pressed = false;
             keyMail.Size = new System.Drawing.Size(47, 46);
@@ -1682,7 +1682,7 @@
             keyCalculator.Enabled = false;
             keyCalculator.Legend = "Calc";
             keyCalculator.Location = new System.Drawing.Point(1210, 70);
-            keyCalculator.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyCalculator.Margin = new System.Windows.Forms.Padding(5);
             keyCalculator.Name = "keyCalculator";
             keyCalculator.Pressed = false;
             keyCalculator.Size = new System.Drawing.Size(47, 46);

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
@@ -1831,6 +1831,7 @@
             Name = "KeyTesterWindow";
             ShowInTaskbar = false;
             Text = "Key Tester";
+            TopMost = true;
             Load += KeyTesterWindow_Load;
             ResumeLayout(false);
         }

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.Designer.cs
@@ -29,1808 +29,1810 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(KeyTesterWindow));
-            this.lblLastVirtualKey = new System.Windows.Forms.Label();
-            this.lblLastScanCode = new System.Windows.Forms.Label();
-            this.keyF1 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF2 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF3 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF4 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF5 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF6 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF7 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF8 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF9 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF10 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF11 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF12 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF13 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF14 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF15 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF16 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF17 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF18 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF19 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF20 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF21 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF22 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF23 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF24 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key1 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key2 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key3 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key4 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key5 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key6 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key7 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key8 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key9 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.key0 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyQ = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyW = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyE = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyR = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyT = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyY = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyU = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyI = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyO = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyP = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyA = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyS = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyD = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyF = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyG = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyH = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyJ = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyK = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyL = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyZ = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyX = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyC = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyV = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyB = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyN = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyM = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyEscape = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyGrave = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMinus = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyEqual = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyBackspace = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyTab = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeftBrace = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRightBrace = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyBackslash = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyCapsLock = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keySemicolon = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyQuote = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyNUHS = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyEnter = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyNUBS = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyComma = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyDot = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keySlash = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keySpace = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMenu = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeftControl = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeftShift = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeftAlt = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeftGUI = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRightControl = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRightShift = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRightAlt = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRightGUI = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPrintScreen = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyScrollLock = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPauseBreak = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyInsert = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyHome = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPageUp = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyDelete = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyEnd = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPageDown = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyUp = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyLeft = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyDown = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyRight = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyNumLock = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadSlash = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadAsterisk = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadMinus = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadPlus = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadEnter = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPadDot = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad0 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad1 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad2 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad3 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad4 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad5 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad6 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad7 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad8 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPad9 = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMute = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyVolumeDown = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyVolumeUp = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyPlayPause = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMediaPrevious = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMediaNext = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyMail = new QMK_Toolbox.KeyTester.KeyControl();
-            this.keyCalculator = new QMK_Toolbox.KeyTester.KeyControl();
-            this.SuspendLayout();
+            lblLastVirtualKey = new System.Windows.Forms.Label();
+            lblLastScanCode = new System.Windows.Forms.Label();
+            keyF1 = new KeyControl();
+            keyF2 = new KeyControl();
+            keyF3 = new KeyControl();
+            keyF4 = new KeyControl();
+            keyF5 = new KeyControl();
+            keyF6 = new KeyControl();
+            keyF7 = new KeyControl();
+            keyF8 = new KeyControl();
+            keyF9 = new KeyControl();
+            keyF10 = new KeyControl();
+            keyF11 = new KeyControl();
+            keyF12 = new KeyControl();
+            keyF13 = new KeyControl();
+            keyF14 = new KeyControl();
+            keyF15 = new KeyControl();
+            keyF16 = new KeyControl();
+            keyF17 = new KeyControl();
+            keyF18 = new KeyControl();
+            keyF19 = new KeyControl();
+            keyF20 = new KeyControl();
+            keyF21 = new KeyControl();
+            keyF22 = new KeyControl();
+            keyF23 = new KeyControl();
+            keyF24 = new KeyControl();
+            key1 = new KeyControl();
+            key2 = new KeyControl();
+            key3 = new KeyControl();
+            key4 = new KeyControl();
+            key5 = new KeyControl();
+            key6 = new KeyControl();
+            key7 = new KeyControl();
+            key8 = new KeyControl();
+            key9 = new KeyControl();
+            key0 = new KeyControl();
+            keyQ = new KeyControl();
+            keyW = new KeyControl();
+            keyE = new KeyControl();
+            keyR = new KeyControl();
+            keyT = new KeyControl();
+            keyY = new KeyControl();
+            keyU = new KeyControl();
+            keyI = new KeyControl();
+            keyO = new KeyControl();
+            keyP = new KeyControl();
+            keyA = new KeyControl();
+            keyS = new KeyControl();
+            keyD = new KeyControl();
+            keyF = new KeyControl();
+            keyG = new KeyControl();
+            keyH = new KeyControl();
+            keyJ = new KeyControl();
+            keyK = new KeyControl();
+            keyL = new KeyControl();
+            keyZ = new KeyControl();
+            keyX = new KeyControl();
+            keyC = new KeyControl();
+            keyV = new KeyControl();
+            keyB = new KeyControl();
+            keyN = new KeyControl();
+            keyM = new KeyControl();
+            keyEscape = new KeyControl();
+            keyGrave = new KeyControl();
+            keyMinus = new KeyControl();
+            keyEqual = new KeyControl();
+            keyBackspace = new KeyControl();
+            keyTab = new KeyControl();
+            keyLeftBrace = new KeyControl();
+            keyRightBrace = new KeyControl();
+            keyBackslash = new KeyControl();
+            keyCapsLock = new KeyControl();
+            keySemicolon = new KeyControl();
+            keyQuote = new KeyControl();
+            keyNUHS = new KeyControl();
+            keyEnter = new KeyControl();
+            keyNUBS = new KeyControl();
+            keyComma = new KeyControl();
+            keyDot = new KeyControl();
+            keySlash = new KeyControl();
+            keySpace = new KeyControl();
+            keyMenu = new KeyControl();
+            keyLeftControl = new KeyControl();
+            keyLeftShift = new KeyControl();
+            keyLeftAlt = new KeyControl();
+            keyLeftGUI = new KeyControl();
+            keyRightControl = new KeyControl();
+            keyRightShift = new KeyControl();
+            keyRightAlt = new KeyControl();
+            keyRightGUI = new KeyControl();
+            keyPrintScreen = new KeyControl();
+            keyScrollLock = new KeyControl();
+            keyPauseBreak = new KeyControl();
+            keyInsert = new KeyControl();
+            keyHome = new KeyControl();
+            keyPageUp = new KeyControl();
+            keyDelete = new KeyControl();
+            keyEnd = new KeyControl();
+            keyPageDown = new KeyControl();
+            keyUp = new KeyControl();
+            keyLeft = new KeyControl();
+            keyDown = new KeyControl();
+            keyRight = new KeyControl();
+            keyNumLock = new KeyControl();
+            keyPadSlash = new KeyControl();
+            keyPadAsterisk = new KeyControl();
+            keyPadMinus = new KeyControl();
+            keyPadPlus = new KeyControl();
+            keyPadEnter = new KeyControl();
+            keyPadDot = new KeyControl();
+            keyPad0 = new KeyControl();
+            keyPad1 = new KeyControl();
+            keyPad2 = new KeyControl();
+            keyPad3 = new KeyControl();
+            keyPad4 = new KeyControl();
+            keyPad5 = new KeyControl();
+            keyPad6 = new KeyControl();
+            keyPad7 = new KeyControl();
+            keyPad8 = new KeyControl();
+            keyPad9 = new KeyControl();
+            keyMute = new KeyControl();
+            keyVolumeDown = new KeyControl();
+            keyVolumeUp = new KeyControl();
+            keyPlayPause = new KeyControl();
+            keyMediaPrevious = new KeyControl();
+            keyMediaNext = new KeyControl();
+            keyMail = new KeyControl();
+            keyCalculator = new KeyControl();
+            SuspendLayout();
             // 
             // lblLastVirtualKey
             // 
-            this.lblLastVirtualKey.Location = new System.Drawing.Point(738, 221);
-            this.lblLastVirtualKey.Name = "lblLastVirtualKey";
-            this.lblLastVirtualKey.Size = new System.Drawing.Size(139, 13);
-            this.lblLastVirtualKey.TabIndex = 0;
-            this.lblLastVirtualKey.Text = "Last VK: -";
+            lblLastVirtualKey.Location = new System.Drawing.Point(861, 255);
+            lblLastVirtualKey.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblLastVirtualKey.Name = "lblLastVirtualKey";
+            lblLastVirtualKey.Size = new System.Drawing.Size(162, 15);
+            lblLastVirtualKey.TabIndex = 0;
+            lblLastVirtualKey.Text = "Last VK: -";
             // 
             // lblLastScanCode
             // 
-            this.lblLastScanCode.Location = new System.Drawing.Point(738, 248);
-            this.lblLastScanCode.Name = "lblLastScanCode";
-            this.lblLastScanCode.Size = new System.Drawing.Size(139, 13);
-            this.lblLastScanCode.TabIndex = 1;
-            this.lblLastScanCode.Text = "Last SC: -";
+            lblLastScanCode.Location = new System.Drawing.Point(861, 286);
+            lblLastScanCode.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblLastScanCode.Name = "lblLastScanCode";
+            lblLastScanCode.Size = new System.Drawing.Size(162, 15);
+            lblLastScanCode.TabIndex = 1;
+            lblLastScanCode.Text = "Last SC: -";
             // 
             // keyF1
             // 
-            this.keyF1.Enabled = false;
-            this.keyF1.Legend = "F1";
-            this.keyF1.Location = new System.Drawing.Point(109, 61);
-            this.keyF1.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF1.Name = "keyF1";
-            this.keyF1.Pressed = false;
-            this.keyF1.Size = new System.Drawing.Size(40, 40);
-            this.keyF1.TabIndex = 2;
-            this.keyF1.Tested = false;
+            keyF1.Enabled = false;
+            keyF1.Legend = "F1";
+            keyF1.Location = new System.Drawing.Point(127, 70);
+            keyF1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF1.Name = "keyF1";
+            keyF1.Pressed = false;
+            keyF1.Size = new System.Drawing.Size(47, 46);
+            keyF1.TabIndex = 2;
+            keyF1.Tested = false;
             // 
             // keyF2
             // 
-            this.keyF2.Enabled = false;
-            this.keyF2.Legend = "F2";
-            this.keyF2.Location = new System.Drawing.Point(157, 61);
-            this.keyF2.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF2.Name = "keyF2";
-            this.keyF2.Pressed = false;
-            this.keyF2.Size = new System.Drawing.Size(40, 40);
-            this.keyF2.TabIndex = 3;
-            this.keyF2.Tested = false;
+            keyF2.Enabled = false;
+            keyF2.Legend = "F2";
+            keyF2.Location = new System.Drawing.Point(183, 70);
+            keyF2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF2.Name = "keyF2";
+            keyF2.Pressed = false;
+            keyF2.Size = new System.Drawing.Size(47, 46);
+            keyF2.TabIndex = 3;
+            keyF2.Tested = false;
             // 
             // keyF3
             // 
-            this.keyF3.Enabled = false;
-            this.keyF3.Legend = "F3";
-            this.keyF3.Location = new System.Drawing.Point(205, 61);
-            this.keyF3.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF3.Name = "keyF3";
-            this.keyF3.Pressed = false;
-            this.keyF3.Size = new System.Drawing.Size(40, 40);
-            this.keyF3.TabIndex = 4;
-            this.keyF3.Tested = false;
+            keyF3.Enabled = false;
+            keyF3.Legend = "F3";
+            keyF3.Location = new System.Drawing.Point(239, 70);
+            keyF3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF3.Name = "keyF3";
+            keyF3.Pressed = false;
+            keyF3.Size = new System.Drawing.Size(47, 46);
+            keyF3.TabIndex = 4;
+            keyF3.Tested = false;
             // 
             // keyF4
             // 
-            this.keyF4.Enabled = false;
-            this.keyF4.Legend = "F4";
-            this.keyF4.Location = new System.Drawing.Point(253, 61);
-            this.keyF4.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF4.Name = "keyF4";
-            this.keyF4.Pressed = false;
-            this.keyF4.Size = new System.Drawing.Size(40, 40);
-            this.keyF4.TabIndex = 5;
-            this.keyF4.Tested = false;
+            keyF4.Enabled = false;
+            keyF4.Legend = "F4";
+            keyF4.Location = new System.Drawing.Point(295, 70);
+            keyF4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF4.Name = "keyF4";
+            keyF4.Pressed = false;
+            keyF4.Size = new System.Drawing.Size(47, 46);
+            keyF4.TabIndex = 5;
+            keyF4.Tested = false;
             // 
             // keyF5
             // 
-            this.keyF5.Enabled = false;
-            this.keyF5.Legend = "F5";
-            this.keyF5.Location = new System.Drawing.Point(325, 61);
-            this.keyF5.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF5.Name = "keyF5";
-            this.keyF5.Pressed = false;
-            this.keyF5.Size = new System.Drawing.Size(40, 40);
-            this.keyF5.TabIndex = 6;
-            this.keyF5.Tested = false;
+            keyF5.Enabled = false;
+            keyF5.Legend = "F5";
+            keyF5.Location = new System.Drawing.Point(379, 70);
+            keyF5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF5.Name = "keyF5";
+            keyF5.Pressed = false;
+            keyF5.Size = new System.Drawing.Size(47, 46);
+            keyF5.TabIndex = 6;
+            keyF5.Tested = false;
             // 
             // keyF6
             // 
-            this.keyF6.Enabled = false;
-            this.keyF6.Legend = "F6";
-            this.keyF6.Location = new System.Drawing.Point(373, 61);
-            this.keyF6.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF6.Name = "keyF6";
-            this.keyF6.Pressed = false;
-            this.keyF6.Size = new System.Drawing.Size(40, 40);
-            this.keyF6.TabIndex = 7;
-            this.keyF6.Tested = false;
+            keyF6.Enabled = false;
+            keyF6.Legend = "F6";
+            keyF6.Location = new System.Drawing.Point(435, 70);
+            keyF6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF6.Name = "keyF6";
+            keyF6.Pressed = false;
+            keyF6.Size = new System.Drawing.Size(47, 46);
+            keyF6.TabIndex = 7;
+            keyF6.Tested = false;
             // 
             // keyF7
             // 
-            this.keyF7.Enabled = false;
-            this.keyF7.Legend = "F7";
-            this.keyF7.Location = new System.Drawing.Point(421, 61);
-            this.keyF7.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF7.Name = "keyF7";
-            this.keyF7.Pressed = false;
-            this.keyF7.Size = new System.Drawing.Size(40, 40);
-            this.keyF7.TabIndex = 8;
-            this.keyF7.Tested = false;
+            keyF7.Enabled = false;
+            keyF7.Legend = "F7";
+            keyF7.Location = new System.Drawing.Point(491, 70);
+            keyF7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF7.Name = "keyF7";
+            keyF7.Pressed = false;
+            keyF7.Size = new System.Drawing.Size(47, 46);
+            keyF7.TabIndex = 8;
+            keyF7.Tested = false;
             // 
             // keyF8
             // 
-            this.keyF8.Enabled = false;
-            this.keyF8.Legend = "F8";
-            this.keyF8.Location = new System.Drawing.Point(469, 61);
-            this.keyF8.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF8.Name = "keyF8";
-            this.keyF8.Pressed = false;
-            this.keyF8.Size = new System.Drawing.Size(40, 40);
-            this.keyF8.TabIndex = 9;
-            this.keyF8.Tested = false;
+            keyF8.Enabled = false;
+            keyF8.Legend = "F8";
+            keyF8.Location = new System.Drawing.Point(547, 70);
+            keyF8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF8.Name = "keyF8";
+            keyF8.Pressed = false;
+            keyF8.Size = new System.Drawing.Size(47, 46);
+            keyF8.TabIndex = 9;
+            keyF8.Tested = false;
             // 
             // keyF9
             // 
-            this.keyF9.Enabled = false;
-            this.keyF9.Legend = "F9";
-            this.keyF9.Location = new System.Drawing.Point(541, 61);
-            this.keyF9.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF9.Name = "keyF9";
-            this.keyF9.Pressed = false;
-            this.keyF9.Size = new System.Drawing.Size(40, 40);
-            this.keyF9.TabIndex = 10;
-            this.keyF9.Tested = false;
+            keyF9.Enabled = false;
+            keyF9.Legend = "F9";
+            keyF9.Location = new System.Drawing.Point(631, 70);
+            keyF9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF9.Name = "keyF9";
+            keyF9.Pressed = false;
+            keyF9.Size = new System.Drawing.Size(47, 46);
+            keyF9.TabIndex = 10;
+            keyF9.Tested = false;
             // 
             // keyF10
             // 
-            this.keyF10.Enabled = false;
-            this.keyF10.Legend = "F10";
-            this.keyF10.Location = new System.Drawing.Point(589, 61);
-            this.keyF10.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF10.Name = "keyF10";
-            this.keyF10.Pressed = false;
-            this.keyF10.Size = new System.Drawing.Size(40, 40);
-            this.keyF10.TabIndex = 11;
-            this.keyF10.Tested = false;
+            keyF10.Enabled = false;
+            keyF10.Legend = "F10";
+            keyF10.Location = new System.Drawing.Point(687, 70);
+            keyF10.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF10.Name = "keyF10";
+            keyF10.Pressed = false;
+            keyF10.Size = new System.Drawing.Size(47, 46);
+            keyF10.TabIndex = 11;
+            keyF10.Tested = false;
             // 
             // keyF11
             // 
-            this.keyF11.Enabled = false;
-            this.keyF11.Legend = "F11";
-            this.keyF11.Location = new System.Drawing.Point(637, 61);
-            this.keyF11.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF11.Name = "keyF11";
-            this.keyF11.Pressed = false;
-            this.keyF11.Size = new System.Drawing.Size(40, 40);
-            this.keyF11.TabIndex = 12;
-            this.keyF11.Tested = false;
+            keyF11.Enabled = false;
+            keyF11.Legend = "F11";
+            keyF11.Location = new System.Drawing.Point(743, 70);
+            keyF11.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF11.Name = "keyF11";
+            keyF11.Pressed = false;
+            keyF11.Size = new System.Drawing.Size(47, 46);
+            keyF11.TabIndex = 12;
+            keyF11.Tested = false;
             // 
             // keyF12
             // 
-            this.keyF12.Enabled = false;
-            this.keyF12.Legend = "F12";
-            this.keyF12.Location = new System.Drawing.Point(685, 61);
-            this.keyF12.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF12.Name = "keyF12";
-            this.keyF12.Pressed = false;
-            this.keyF12.Size = new System.Drawing.Size(40, 40);
-            this.keyF12.TabIndex = 13;
-            this.keyF12.Tested = false;
+            keyF12.Enabled = false;
+            keyF12.Legend = "F12";
+            keyF12.Location = new System.Drawing.Point(799, 70);
+            keyF12.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF12.Name = "keyF12";
+            keyF12.Pressed = false;
+            keyF12.Size = new System.Drawing.Size(47, 46);
+            keyF12.TabIndex = 13;
+            keyF12.Tested = false;
             // 
             // keyF13
             // 
-            this.keyF13.Enabled = false;
-            this.keyF13.Legend = "F13";
-            this.keyF13.Location = new System.Drawing.Point(109, 13);
-            this.keyF13.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF13.Name = "keyF13";
-            this.keyF13.Pressed = false;
-            this.keyF13.Size = new System.Drawing.Size(40, 40);
-            this.keyF13.TabIndex = 14;
-            this.keyF13.Tested = false;
+            keyF13.Enabled = false;
+            keyF13.Legend = "F13";
+            keyF13.Location = new System.Drawing.Point(127, 15);
+            keyF13.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF13.Name = "keyF13";
+            keyF13.Pressed = false;
+            keyF13.Size = new System.Drawing.Size(47, 46);
+            keyF13.TabIndex = 14;
+            keyF13.Tested = false;
             // 
             // keyF14
             // 
-            this.keyF14.Enabled = false;
-            this.keyF14.Legend = "F14";
-            this.keyF14.Location = new System.Drawing.Point(157, 13);
-            this.keyF14.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF14.Name = "keyF14";
-            this.keyF14.Pressed = false;
-            this.keyF14.Size = new System.Drawing.Size(40, 40);
-            this.keyF14.TabIndex = 15;
-            this.keyF14.Tested = false;
+            keyF14.Enabled = false;
+            keyF14.Legend = "F14";
+            keyF14.Location = new System.Drawing.Point(183, 15);
+            keyF14.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF14.Name = "keyF14";
+            keyF14.Pressed = false;
+            keyF14.Size = new System.Drawing.Size(47, 46);
+            keyF14.TabIndex = 15;
+            keyF14.Tested = false;
             // 
             // keyF15
             // 
-            this.keyF15.Enabled = false;
-            this.keyF15.Legend = "F15";
-            this.keyF15.Location = new System.Drawing.Point(205, 13);
-            this.keyF15.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF15.Name = "keyF15";
-            this.keyF15.Pressed = false;
-            this.keyF15.Size = new System.Drawing.Size(40, 40);
-            this.keyF15.TabIndex = 16;
-            this.keyF15.Tested = false;
+            keyF15.Enabled = false;
+            keyF15.Legend = "F15";
+            keyF15.Location = new System.Drawing.Point(239, 15);
+            keyF15.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF15.Name = "keyF15";
+            keyF15.Pressed = false;
+            keyF15.Size = new System.Drawing.Size(47, 46);
+            keyF15.TabIndex = 16;
+            keyF15.Tested = false;
             // 
             // keyF16
             // 
-            this.keyF16.Enabled = false;
-            this.keyF16.Legend = "F16";
-            this.keyF16.Location = new System.Drawing.Point(253, 13);
-            this.keyF16.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF16.Name = "keyF16";
-            this.keyF16.Pressed = false;
-            this.keyF16.Size = new System.Drawing.Size(40, 40);
-            this.keyF16.TabIndex = 17;
-            this.keyF16.Tested = false;
+            keyF16.Enabled = false;
+            keyF16.Legend = "F16";
+            keyF16.Location = new System.Drawing.Point(295, 15);
+            keyF16.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF16.Name = "keyF16";
+            keyF16.Pressed = false;
+            keyF16.Size = new System.Drawing.Size(47, 46);
+            keyF16.TabIndex = 17;
+            keyF16.Tested = false;
             // 
             // keyF17
             // 
-            this.keyF17.Enabled = false;
-            this.keyF17.Legend = "F17";
-            this.keyF17.Location = new System.Drawing.Point(325, 13);
-            this.keyF17.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF17.Name = "keyF17";
-            this.keyF17.Pressed = false;
-            this.keyF17.Size = new System.Drawing.Size(40, 40);
-            this.keyF17.TabIndex = 18;
-            this.keyF17.Tested = false;
+            keyF17.Enabled = false;
+            keyF17.Legend = "F17";
+            keyF17.Location = new System.Drawing.Point(379, 15);
+            keyF17.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF17.Name = "keyF17";
+            keyF17.Pressed = false;
+            keyF17.Size = new System.Drawing.Size(47, 46);
+            keyF17.TabIndex = 18;
+            keyF17.Tested = false;
             // 
             // keyF18
             // 
-            this.keyF18.Enabled = false;
-            this.keyF18.Legend = "F18";
-            this.keyF18.Location = new System.Drawing.Point(373, 13);
-            this.keyF18.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF18.Name = "keyF18";
-            this.keyF18.Pressed = false;
-            this.keyF18.Size = new System.Drawing.Size(40, 40);
-            this.keyF18.TabIndex = 19;
-            this.keyF18.Tested = false;
+            keyF18.Enabled = false;
+            keyF18.Legend = "F18";
+            keyF18.Location = new System.Drawing.Point(435, 15);
+            keyF18.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF18.Name = "keyF18";
+            keyF18.Pressed = false;
+            keyF18.Size = new System.Drawing.Size(47, 46);
+            keyF18.TabIndex = 19;
+            keyF18.Tested = false;
             // 
             // keyF19
             // 
-            this.keyF19.Enabled = false;
-            this.keyF19.Legend = "F19";
-            this.keyF19.Location = new System.Drawing.Point(421, 13);
-            this.keyF19.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF19.Name = "keyF19";
-            this.keyF19.Pressed = false;
-            this.keyF19.Size = new System.Drawing.Size(40, 40);
-            this.keyF19.TabIndex = 20;
-            this.keyF19.Tested = false;
+            keyF19.Enabled = false;
+            keyF19.Legend = "F19";
+            keyF19.Location = new System.Drawing.Point(491, 15);
+            keyF19.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF19.Name = "keyF19";
+            keyF19.Pressed = false;
+            keyF19.Size = new System.Drawing.Size(47, 46);
+            keyF19.TabIndex = 20;
+            keyF19.Tested = false;
             // 
             // keyF20
             // 
-            this.keyF20.Enabled = false;
-            this.keyF20.Legend = "F20";
-            this.keyF20.Location = new System.Drawing.Point(469, 13);
-            this.keyF20.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF20.Name = "keyF20";
-            this.keyF20.Pressed = false;
-            this.keyF20.Size = new System.Drawing.Size(40, 40);
-            this.keyF20.TabIndex = 21;
-            this.keyF20.Tested = false;
+            keyF20.Enabled = false;
+            keyF20.Legend = "F20";
+            keyF20.Location = new System.Drawing.Point(547, 15);
+            keyF20.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF20.Name = "keyF20";
+            keyF20.Pressed = false;
+            keyF20.Size = new System.Drawing.Size(47, 46);
+            keyF20.TabIndex = 21;
+            keyF20.Tested = false;
             // 
             // keyF21
             // 
-            this.keyF21.Enabled = false;
-            this.keyF21.Legend = "F21";
-            this.keyF21.Location = new System.Drawing.Point(541, 13);
-            this.keyF21.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF21.Name = "keyF21";
-            this.keyF21.Pressed = false;
-            this.keyF21.Size = new System.Drawing.Size(40, 40);
-            this.keyF21.TabIndex = 22;
-            this.keyF21.Tested = false;
+            keyF21.Enabled = false;
+            keyF21.Legend = "F21";
+            keyF21.Location = new System.Drawing.Point(631, 15);
+            keyF21.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF21.Name = "keyF21";
+            keyF21.Pressed = false;
+            keyF21.Size = new System.Drawing.Size(47, 46);
+            keyF21.TabIndex = 22;
+            keyF21.Tested = false;
             // 
             // keyF22
             // 
-            this.keyF22.Enabled = false;
-            this.keyF22.Legend = "F22";
-            this.keyF22.Location = new System.Drawing.Point(589, 13);
-            this.keyF22.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF22.Name = "keyF22";
-            this.keyF22.Pressed = false;
-            this.keyF22.Size = new System.Drawing.Size(40, 40);
-            this.keyF22.TabIndex = 23;
-            this.keyF22.Tested = false;
+            keyF22.Enabled = false;
+            keyF22.Legend = "F22";
+            keyF22.Location = new System.Drawing.Point(687, 15);
+            keyF22.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF22.Name = "keyF22";
+            keyF22.Pressed = false;
+            keyF22.Size = new System.Drawing.Size(47, 46);
+            keyF22.TabIndex = 23;
+            keyF22.Tested = false;
             // 
             // keyF23
             // 
-            this.keyF23.Enabled = false;
-            this.keyF23.Legend = "F23";
-            this.keyF23.Location = new System.Drawing.Point(637, 13);
-            this.keyF23.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF23.Name = "keyF23";
-            this.keyF23.Pressed = false;
-            this.keyF23.Size = new System.Drawing.Size(40, 40);
-            this.keyF23.TabIndex = 24;
-            this.keyF23.Tested = false;
+            keyF23.Enabled = false;
+            keyF23.Legend = "F23";
+            keyF23.Location = new System.Drawing.Point(743, 15);
+            keyF23.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF23.Name = "keyF23";
+            keyF23.Pressed = false;
+            keyF23.Size = new System.Drawing.Size(47, 46);
+            keyF23.TabIndex = 24;
+            keyF23.Tested = false;
             // 
             // keyF24
             // 
-            this.keyF24.Enabled = false;
-            this.keyF24.Legend = "F24";
-            this.keyF24.Location = new System.Drawing.Point(685, 13);
-            this.keyF24.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF24.Name = "keyF24";
-            this.keyF24.Pressed = false;
-            this.keyF24.Size = new System.Drawing.Size(40, 40);
-            this.keyF24.TabIndex = 25;
-            this.keyF24.Tested = false;
+            keyF24.Enabled = false;
+            keyF24.Legend = "F24";
+            keyF24.Location = new System.Drawing.Point(799, 15);
+            keyF24.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF24.Name = "keyF24";
+            keyF24.Pressed = false;
+            keyF24.Size = new System.Drawing.Size(47, 46);
+            keyF24.TabIndex = 25;
+            keyF24.Tested = false;
             // 
             // key1
             // 
-            this.key1.Enabled = false;
-            this.key1.Legend = "!\r\n1";
-            this.key1.Location = new System.Drawing.Point(61, 125);
-            this.key1.Margin = new System.Windows.Forms.Padding(4);
-            this.key1.Name = "key1";
-            this.key1.Pressed = false;
-            this.key1.Size = new System.Drawing.Size(40, 40);
-            this.key1.TabIndex = 26;
-            this.key1.Tested = false;
+            key1.Enabled = false;
+            key1.Legend = "!\r\n1";
+            key1.Location = new System.Drawing.Point(71, 144);
+            key1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key1.Name = "key1";
+            key1.Pressed = false;
+            key1.Size = new System.Drawing.Size(47, 46);
+            key1.TabIndex = 26;
+            key1.Tested = false;
             // 
             // key2
             // 
-            this.key2.Enabled = false;
-            this.key2.Legend = "@\r\n2";
-            this.key2.Location = new System.Drawing.Point(109, 125);
-            this.key2.Margin = new System.Windows.Forms.Padding(4);
-            this.key2.Name = "key2";
-            this.key2.Pressed = false;
-            this.key2.Size = new System.Drawing.Size(40, 40);
-            this.key2.TabIndex = 27;
-            this.key2.Tested = false;
+            key2.Enabled = false;
+            key2.Legend = "@\r\n2";
+            key2.Location = new System.Drawing.Point(127, 144);
+            key2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key2.Name = "key2";
+            key2.Pressed = false;
+            key2.Size = new System.Drawing.Size(47, 46);
+            key2.TabIndex = 27;
+            key2.Tested = false;
             // 
             // key3
             // 
-            this.key3.Enabled = false;
-            this.key3.Legend = "#\r\n3";
-            this.key3.Location = new System.Drawing.Point(157, 125);
-            this.key3.Margin = new System.Windows.Forms.Padding(4);
-            this.key3.Name = "key3";
-            this.key3.Pressed = false;
-            this.key3.Size = new System.Drawing.Size(40, 40);
-            this.key3.TabIndex = 28;
-            this.key3.Tested = false;
+            key3.Enabled = false;
+            key3.Legend = "#\r\n3";
+            key3.Location = new System.Drawing.Point(183, 144);
+            key3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key3.Name = "key3";
+            key3.Pressed = false;
+            key3.Size = new System.Drawing.Size(47, 46);
+            key3.TabIndex = 28;
+            key3.Tested = false;
             // 
             // key4
             // 
-            this.key4.Enabled = false;
-            this.key4.Legend = "$\r\n4";
-            this.key4.Location = new System.Drawing.Point(205, 125);
-            this.key4.Margin = new System.Windows.Forms.Padding(4);
-            this.key4.Name = "key4";
-            this.key4.Pressed = false;
-            this.key4.Size = new System.Drawing.Size(40, 40);
-            this.key4.TabIndex = 29;
-            this.key4.Tested = false;
+            key4.Enabled = false;
+            key4.Legend = "$\r\n4";
+            key4.Location = new System.Drawing.Point(239, 144);
+            key4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key4.Name = "key4";
+            key4.Pressed = false;
+            key4.Size = new System.Drawing.Size(47, 46);
+            key4.TabIndex = 29;
+            key4.Tested = false;
             // 
             // key5
             // 
-            this.key5.Enabled = false;
-            this.key5.Legend = "%\r\n5";
-            this.key5.Location = new System.Drawing.Point(253, 125);
-            this.key5.Margin = new System.Windows.Forms.Padding(4);
-            this.key5.Name = "key5";
-            this.key5.Pressed = false;
-            this.key5.Size = new System.Drawing.Size(40, 40);
-            this.key5.TabIndex = 30;
-            this.key5.Tested = false;
+            key5.Enabled = false;
+            key5.Legend = "%\r\n5";
+            key5.Location = new System.Drawing.Point(295, 144);
+            key5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key5.Name = "key5";
+            key5.Pressed = false;
+            key5.Size = new System.Drawing.Size(47, 46);
+            key5.TabIndex = 30;
+            key5.Tested = false;
             // 
             // key6
             // 
-            this.key6.Enabled = false;
-            this.key6.Legend = "^\r\n6";
-            this.key6.Location = new System.Drawing.Point(301, 125);
-            this.key6.Margin = new System.Windows.Forms.Padding(4);
-            this.key6.Name = "key6";
-            this.key6.Pressed = false;
-            this.key6.Size = new System.Drawing.Size(40, 40);
-            this.key6.TabIndex = 31;
-            this.key6.Tested = false;
+            key6.Enabled = false;
+            key6.Legend = "^\r\n6";
+            key6.Location = new System.Drawing.Point(351, 144);
+            key6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key6.Name = "key6";
+            key6.Pressed = false;
+            key6.Size = new System.Drawing.Size(47, 46);
+            key6.TabIndex = 31;
+            key6.Tested = false;
             // 
             // key7
             // 
-            this.key7.Enabled = false;
-            this.key7.Legend = "&&\r\n7";
-            this.key7.Location = new System.Drawing.Point(349, 125);
-            this.key7.Margin = new System.Windows.Forms.Padding(4);
-            this.key7.Name = "key7";
-            this.key7.Pressed = false;
-            this.key7.Size = new System.Drawing.Size(40, 40);
-            this.key7.TabIndex = 32;
-            this.key7.Tested = false;
+            key7.Enabled = false;
+            key7.Legend = "&&\r\n7";
+            key7.Location = new System.Drawing.Point(407, 144);
+            key7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key7.Name = "key7";
+            key7.Pressed = false;
+            key7.Size = new System.Drawing.Size(47, 46);
+            key7.TabIndex = 32;
+            key7.Tested = false;
             // 
             // key8
             // 
-            this.key8.Enabled = false;
-            this.key8.Legend = "*\r\n8";
-            this.key8.Location = new System.Drawing.Point(397, 125);
-            this.key8.Margin = new System.Windows.Forms.Padding(4);
-            this.key8.Name = "key8";
-            this.key8.Pressed = false;
-            this.key8.Size = new System.Drawing.Size(40, 40);
-            this.key8.TabIndex = 33;
-            this.key8.Tested = false;
+            key8.Enabled = false;
+            key8.Legend = "*\r\n8";
+            key8.Location = new System.Drawing.Point(463, 144);
+            key8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key8.Name = "key8";
+            key8.Pressed = false;
+            key8.Size = new System.Drawing.Size(47, 46);
+            key8.TabIndex = 33;
+            key8.Tested = false;
             // 
             // key9
             // 
-            this.key9.Enabled = false;
-            this.key9.Legend = "(\r\n9";
-            this.key9.Location = new System.Drawing.Point(445, 125);
-            this.key9.Margin = new System.Windows.Forms.Padding(4);
-            this.key9.Name = "key9";
-            this.key9.Pressed = false;
-            this.key9.Size = new System.Drawing.Size(40, 40);
-            this.key9.TabIndex = 34;
-            this.key9.Tested = false;
+            key9.Enabled = false;
+            key9.Legend = "(\r\n9";
+            key9.Location = new System.Drawing.Point(519, 144);
+            key9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key9.Name = "key9";
+            key9.Pressed = false;
+            key9.Size = new System.Drawing.Size(47, 46);
+            key9.TabIndex = 34;
+            key9.Tested = false;
             // 
             // key0
             // 
-            this.key0.Enabled = false;
-            this.key0.Legend = ")\r\n0";
-            this.key0.Location = new System.Drawing.Point(493, 125);
-            this.key0.Margin = new System.Windows.Forms.Padding(4);
-            this.key0.Name = "key0";
-            this.key0.Pressed = false;
-            this.key0.Size = new System.Drawing.Size(40, 40);
-            this.key0.TabIndex = 35;
-            this.key0.Tested = false;
+            key0.Enabled = false;
+            key0.Legend = ")\r\n0";
+            key0.Location = new System.Drawing.Point(575, 144);
+            key0.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            key0.Name = "key0";
+            key0.Pressed = false;
+            key0.Size = new System.Drawing.Size(47, 46);
+            key0.TabIndex = 35;
+            key0.Tested = false;
             // 
             // keyQ
             // 
-            this.keyQ.Enabled = false;
-            this.keyQ.Legend = "Q";
-            this.keyQ.Location = new System.Drawing.Point(85, 173);
-            this.keyQ.Margin = new System.Windows.Forms.Padding(4);
-            this.keyQ.Name = "keyQ";
-            this.keyQ.Pressed = false;
-            this.keyQ.Size = new System.Drawing.Size(40, 40);
-            this.keyQ.TabIndex = 36;
-            this.keyQ.Tested = false;
+            keyQ.Enabled = false;
+            keyQ.Legend = "Q";
+            keyQ.Location = new System.Drawing.Point(99, 200);
+            keyQ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyQ.Name = "keyQ";
+            keyQ.Pressed = false;
+            keyQ.Size = new System.Drawing.Size(47, 46);
+            keyQ.TabIndex = 36;
+            keyQ.Tested = false;
             // 
             // keyW
             // 
-            this.keyW.Enabled = false;
-            this.keyW.Legend = "W";
-            this.keyW.Location = new System.Drawing.Point(133, 173);
-            this.keyW.Margin = new System.Windows.Forms.Padding(4);
-            this.keyW.Name = "keyW";
-            this.keyW.Pressed = false;
-            this.keyW.Size = new System.Drawing.Size(40, 40);
-            this.keyW.TabIndex = 37;
-            this.keyW.Tested = false;
+            keyW.Enabled = false;
+            keyW.Legend = "W";
+            keyW.Location = new System.Drawing.Point(155, 200);
+            keyW.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyW.Name = "keyW";
+            keyW.Pressed = false;
+            keyW.Size = new System.Drawing.Size(47, 46);
+            keyW.TabIndex = 37;
+            keyW.Tested = false;
             // 
             // keyE
             // 
-            this.keyE.Enabled = false;
-            this.keyE.Legend = "E";
-            this.keyE.Location = new System.Drawing.Point(181, 173);
-            this.keyE.Margin = new System.Windows.Forms.Padding(4);
-            this.keyE.Name = "keyE";
-            this.keyE.Pressed = false;
-            this.keyE.Size = new System.Drawing.Size(40, 40);
-            this.keyE.TabIndex = 38;
-            this.keyE.Tested = false;
+            keyE.Enabled = false;
+            keyE.Legend = "E";
+            keyE.Location = new System.Drawing.Point(211, 200);
+            keyE.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyE.Name = "keyE";
+            keyE.Pressed = false;
+            keyE.Size = new System.Drawing.Size(47, 46);
+            keyE.TabIndex = 38;
+            keyE.Tested = false;
             // 
             // keyR
             // 
-            this.keyR.Enabled = false;
-            this.keyR.Legend = "R";
-            this.keyR.Location = new System.Drawing.Point(229, 173);
-            this.keyR.Margin = new System.Windows.Forms.Padding(4);
-            this.keyR.Name = "keyR";
-            this.keyR.Pressed = false;
-            this.keyR.Size = new System.Drawing.Size(40, 40);
-            this.keyR.TabIndex = 39;
-            this.keyR.Tested = false;
+            keyR.Enabled = false;
+            keyR.Legend = "R";
+            keyR.Location = new System.Drawing.Point(267, 200);
+            keyR.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyR.Name = "keyR";
+            keyR.Pressed = false;
+            keyR.Size = new System.Drawing.Size(47, 46);
+            keyR.TabIndex = 39;
+            keyR.Tested = false;
             // 
             // keyT
             // 
-            this.keyT.Enabled = false;
-            this.keyT.Legend = "T";
-            this.keyT.Location = new System.Drawing.Point(277, 173);
-            this.keyT.Margin = new System.Windows.Forms.Padding(4);
-            this.keyT.Name = "keyT";
-            this.keyT.Pressed = false;
-            this.keyT.Size = new System.Drawing.Size(40, 40);
-            this.keyT.TabIndex = 40;
-            this.keyT.Tested = false;
+            keyT.Enabled = false;
+            keyT.Legend = "T";
+            keyT.Location = new System.Drawing.Point(323, 200);
+            keyT.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyT.Name = "keyT";
+            keyT.Pressed = false;
+            keyT.Size = new System.Drawing.Size(47, 46);
+            keyT.TabIndex = 40;
+            keyT.Tested = false;
             // 
             // keyY
             // 
-            this.keyY.Enabled = false;
-            this.keyY.Legend = "Y";
-            this.keyY.Location = new System.Drawing.Point(325, 173);
-            this.keyY.Margin = new System.Windows.Forms.Padding(4);
-            this.keyY.Name = "keyY";
-            this.keyY.Pressed = false;
-            this.keyY.Size = new System.Drawing.Size(40, 40);
-            this.keyY.TabIndex = 41;
-            this.keyY.Tested = false;
+            keyY.Enabled = false;
+            keyY.Legend = "Y";
+            keyY.Location = new System.Drawing.Point(379, 200);
+            keyY.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyY.Name = "keyY";
+            keyY.Pressed = false;
+            keyY.Size = new System.Drawing.Size(47, 46);
+            keyY.TabIndex = 41;
+            keyY.Tested = false;
             // 
             // keyU
             // 
-            this.keyU.Enabled = false;
-            this.keyU.Legend = "U";
-            this.keyU.Location = new System.Drawing.Point(373, 173);
-            this.keyU.Margin = new System.Windows.Forms.Padding(4);
-            this.keyU.Name = "keyU";
-            this.keyU.Pressed = false;
-            this.keyU.Size = new System.Drawing.Size(40, 40);
-            this.keyU.TabIndex = 42;
-            this.keyU.Tested = false;
+            keyU.Enabled = false;
+            keyU.Legend = "U";
+            keyU.Location = new System.Drawing.Point(435, 200);
+            keyU.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyU.Name = "keyU";
+            keyU.Pressed = false;
+            keyU.Size = new System.Drawing.Size(47, 46);
+            keyU.TabIndex = 42;
+            keyU.Tested = false;
             // 
             // keyI
             // 
-            this.keyI.Enabled = false;
-            this.keyI.Legend = "I";
-            this.keyI.Location = new System.Drawing.Point(421, 173);
-            this.keyI.Margin = new System.Windows.Forms.Padding(4);
-            this.keyI.Name = "keyI";
-            this.keyI.Pressed = false;
-            this.keyI.Size = new System.Drawing.Size(40, 40);
-            this.keyI.TabIndex = 43;
-            this.keyI.Tested = false;
+            keyI.Enabled = false;
+            keyI.Legend = "I";
+            keyI.Location = new System.Drawing.Point(491, 200);
+            keyI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyI.Name = "keyI";
+            keyI.Pressed = false;
+            keyI.Size = new System.Drawing.Size(47, 46);
+            keyI.TabIndex = 43;
+            keyI.Tested = false;
             // 
             // keyO
             // 
-            this.keyO.Enabled = false;
-            this.keyO.Legend = "O";
-            this.keyO.Location = new System.Drawing.Point(469, 173);
-            this.keyO.Margin = new System.Windows.Forms.Padding(4);
-            this.keyO.Name = "keyO";
-            this.keyO.Pressed = false;
-            this.keyO.Size = new System.Drawing.Size(40, 40);
-            this.keyO.TabIndex = 44;
-            this.keyO.Tested = false;
+            keyO.Enabled = false;
+            keyO.Legend = "O";
+            keyO.Location = new System.Drawing.Point(547, 200);
+            keyO.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyO.Name = "keyO";
+            keyO.Pressed = false;
+            keyO.Size = new System.Drawing.Size(47, 46);
+            keyO.TabIndex = 44;
+            keyO.Tested = false;
             // 
             // keyP
             // 
-            this.keyP.Enabled = false;
-            this.keyP.Legend = "P";
-            this.keyP.Location = new System.Drawing.Point(517, 173);
-            this.keyP.Margin = new System.Windows.Forms.Padding(4);
-            this.keyP.Name = "keyP";
-            this.keyP.Pressed = false;
-            this.keyP.Size = new System.Drawing.Size(40, 40);
-            this.keyP.TabIndex = 45;
-            this.keyP.Tested = false;
+            keyP.Enabled = false;
+            keyP.Legend = "P";
+            keyP.Location = new System.Drawing.Point(603, 200);
+            keyP.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyP.Name = "keyP";
+            keyP.Pressed = false;
+            keyP.Size = new System.Drawing.Size(47, 46);
+            keyP.TabIndex = 45;
+            keyP.Tested = false;
             // 
             // keyA
             // 
-            this.keyA.Enabled = false;
-            this.keyA.Legend = "A";
-            this.keyA.Location = new System.Drawing.Point(97, 221);
-            this.keyA.Margin = new System.Windows.Forms.Padding(4);
-            this.keyA.Name = "keyA";
-            this.keyA.Pressed = false;
-            this.keyA.Size = new System.Drawing.Size(40, 40);
-            this.keyA.TabIndex = 46;
-            this.keyA.Tested = false;
+            keyA.Enabled = false;
+            keyA.Legend = "A";
+            keyA.Location = new System.Drawing.Point(113, 255);
+            keyA.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyA.Name = "keyA";
+            keyA.Pressed = false;
+            keyA.Size = new System.Drawing.Size(47, 46);
+            keyA.TabIndex = 46;
+            keyA.Tested = false;
             // 
             // keyS
             // 
-            this.keyS.Enabled = false;
-            this.keyS.Legend = "S";
-            this.keyS.Location = new System.Drawing.Point(145, 221);
-            this.keyS.Margin = new System.Windows.Forms.Padding(4);
-            this.keyS.Name = "keyS";
-            this.keyS.Pressed = false;
-            this.keyS.Size = new System.Drawing.Size(40, 40);
-            this.keyS.TabIndex = 47;
-            this.keyS.Tested = false;
+            keyS.Enabled = false;
+            keyS.Legend = "S";
+            keyS.Location = new System.Drawing.Point(169, 255);
+            keyS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyS.Name = "keyS";
+            keyS.Pressed = false;
+            keyS.Size = new System.Drawing.Size(47, 46);
+            keyS.TabIndex = 47;
+            keyS.Tested = false;
             // 
             // keyD
             // 
-            this.keyD.Enabled = false;
-            this.keyD.Legend = "D";
-            this.keyD.Location = new System.Drawing.Point(193, 221);
-            this.keyD.Margin = new System.Windows.Forms.Padding(4);
-            this.keyD.Name = "keyD";
-            this.keyD.Pressed = false;
-            this.keyD.Size = new System.Drawing.Size(40, 40);
-            this.keyD.TabIndex = 48;
-            this.keyD.Tested = false;
+            keyD.Enabled = false;
+            keyD.Legend = "D";
+            keyD.Location = new System.Drawing.Point(225, 255);
+            keyD.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyD.Name = "keyD";
+            keyD.Pressed = false;
+            keyD.Size = new System.Drawing.Size(47, 46);
+            keyD.TabIndex = 48;
+            keyD.Tested = false;
             // 
             // keyF
             // 
-            this.keyF.Enabled = false;
-            this.keyF.Legend = "F";
-            this.keyF.Location = new System.Drawing.Point(241, 221);
-            this.keyF.Margin = new System.Windows.Forms.Padding(4);
-            this.keyF.Name = "keyF";
-            this.keyF.Pressed = false;
-            this.keyF.Size = new System.Drawing.Size(40, 40);
-            this.keyF.TabIndex = 49;
-            this.keyF.Tested = false;
+            keyF.Enabled = false;
+            keyF.Legend = "F";
+            keyF.Location = new System.Drawing.Point(281, 255);
+            keyF.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyF.Name = "keyF";
+            keyF.Pressed = false;
+            keyF.Size = new System.Drawing.Size(47, 46);
+            keyF.TabIndex = 49;
+            keyF.Tested = false;
             // 
             // keyG
             // 
-            this.keyG.Enabled = false;
-            this.keyG.Legend = "G";
-            this.keyG.Location = new System.Drawing.Point(289, 221);
-            this.keyG.Margin = new System.Windows.Forms.Padding(4);
-            this.keyG.Name = "keyG";
-            this.keyG.Pressed = false;
-            this.keyG.Size = new System.Drawing.Size(40, 40);
-            this.keyG.TabIndex = 50;
-            this.keyG.Tested = false;
+            keyG.Enabled = false;
+            keyG.Legend = "G";
+            keyG.Location = new System.Drawing.Point(337, 255);
+            keyG.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyG.Name = "keyG";
+            keyG.Pressed = false;
+            keyG.Size = new System.Drawing.Size(47, 46);
+            keyG.TabIndex = 50;
+            keyG.Tested = false;
             // 
             // keyH
             // 
-            this.keyH.Enabled = false;
-            this.keyH.Legend = "H";
-            this.keyH.Location = new System.Drawing.Point(337, 221);
-            this.keyH.Margin = new System.Windows.Forms.Padding(4);
-            this.keyH.Name = "keyH";
-            this.keyH.Pressed = false;
-            this.keyH.Size = new System.Drawing.Size(40, 40);
-            this.keyH.TabIndex = 51;
-            this.keyH.Tested = false;
+            keyH.Enabled = false;
+            keyH.Legend = "H";
+            keyH.Location = new System.Drawing.Point(393, 255);
+            keyH.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyH.Name = "keyH";
+            keyH.Pressed = false;
+            keyH.Size = new System.Drawing.Size(47, 46);
+            keyH.TabIndex = 51;
+            keyH.Tested = false;
             // 
             // keyJ
             // 
-            this.keyJ.Enabled = false;
-            this.keyJ.Legend = "J";
-            this.keyJ.Location = new System.Drawing.Point(385, 221);
-            this.keyJ.Margin = new System.Windows.Forms.Padding(4);
-            this.keyJ.Name = "keyJ";
-            this.keyJ.Pressed = false;
-            this.keyJ.Size = new System.Drawing.Size(40, 40);
-            this.keyJ.TabIndex = 52;
-            this.keyJ.Tested = false;
+            keyJ.Enabled = false;
+            keyJ.Legend = "J";
+            keyJ.Location = new System.Drawing.Point(449, 255);
+            keyJ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyJ.Name = "keyJ";
+            keyJ.Pressed = false;
+            keyJ.Size = new System.Drawing.Size(47, 46);
+            keyJ.TabIndex = 52;
+            keyJ.Tested = false;
             // 
             // keyK
             // 
-            this.keyK.Enabled = false;
-            this.keyK.Legend = "K";
-            this.keyK.Location = new System.Drawing.Point(433, 221);
-            this.keyK.Margin = new System.Windows.Forms.Padding(4);
-            this.keyK.Name = "keyK";
-            this.keyK.Pressed = false;
-            this.keyK.Size = new System.Drawing.Size(40, 40);
-            this.keyK.TabIndex = 53;
-            this.keyK.Tested = false;
+            keyK.Enabled = false;
+            keyK.Legend = "K";
+            keyK.Location = new System.Drawing.Point(505, 255);
+            keyK.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyK.Name = "keyK";
+            keyK.Pressed = false;
+            keyK.Size = new System.Drawing.Size(47, 46);
+            keyK.TabIndex = 53;
+            keyK.Tested = false;
             // 
             // keyL
             // 
-            this.keyL.Enabled = false;
-            this.keyL.Legend = "L";
-            this.keyL.Location = new System.Drawing.Point(481, 221);
-            this.keyL.Margin = new System.Windows.Forms.Padding(4);
-            this.keyL.Name = "keyL";
-            this.keyL.Pressed = false;
-            this.keyL.Size = new System.Drawing.Size(40, 40);
-            this.keyL.TabIndex = 54;
-            this.keyL.Tested = false;
+            keyL.Enabled = false;
+            keyL.Legend = "L";
+            keyL.Location = new System.Drawing.Point(561, 255);
+            keyL.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyL.Name = "keyL";
+            keyL.Pressed = false;
+            keyL.Size = new System.Drawing.Size(47, 46);
+            keyL.TabIndex = 54;
+            keyL.Tested = false;
             // 
             // keyZ
             // 
-            this.keyZ.Enabled = false;
-            this.keyZ.Legend = "Z";
-            this.keyZ.Location = new System.Drawing.Point(121, 269);
-            this.keyZ.Margin = new System.Windows.Forms.Padding(4);
-            this.keyZ.Name = "keyZ";
-            this.keyZ.Pressed = false;
-            this.keyZ.Size = new System.Drawing.Size(40, 40);
-            this.keyZ.TabIndex = 55;
-            this.keyZ.Tested = false;
+            keyZ.Enabled = false;
+            keyZ.Legend = "Z";
+            keyZ.Location = new System.Drawing.Point(141, 310);
+            keyZ.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyZ.Name = "keyZ";
+            keyZ.Pressed = false;
+            keyZ.Size = new System.Drawing.Size(47, 46);
+            keyZ.TabIndex = 55;
+            keyZ.Tested = false;
             // 
             // keyX
             // 
-            this.keyX.Enabled = false;
-            this.keyX.Legend = "X";
-            this.keyX.Location = new System.Drawing.Point(169, 269);
-            this.keyX.Margin = new System.Windows.Forms.Padding(4);
-            this.keyX.Name = "keyX";
-            this.keyX.Pressed = false;
-            this.keyX.Size = new System.Drawing.Size(40, 40);
-            this.keyX.TabIndex = 56;
-            this.keyX.Tested = false;
+            keyX.Enabled = false;
+            keyX.Legend = "X";
+            keyX.Location = new System.Drawing.Point(197, 310);
+            keyX.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyX.Name = "keyX";
+            keyX.Pressed = false;
+            keyX.Size = new System.Drawing.Size(47, 46);
+            keyX.TabIndex = 56;
+            keyX.Tested = false;
             // 
             // keyC
             // 
-            this.keyC.Enabled = false;
-            this.keyC.Legend = "C";
-            this.keyC.Location = new System.Drawing.Point(217, 269);
-            this.keyC.Margin = new System.Windows.Forms.Padding(4);
-            this.keyC.Name = "keyC";
-            this.keyC.Pressed = false;
-            this.keyC.Size = new System.Drawing.Size(40, 40);
-            this.keyC.TabIndex = 57;
-            this.keyC.Tested = false;
+            keyC.Enabled = false;
+            keyC.Legend = "C";
+            keyC.Location = new System.Drawing.Point(253, 310);
+            keyC.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyC.Name = "keyC";
+            keyC.Pressed = false;
+            keyC.Size = new System.Drawing.Size(47, 46);
+            keyC.TabIndex = 57;
+            keyC.Tested = false;
             // 
             // keyV
             // 
-            this.keyV.Enabled = false;
-            this.keyV.Legend = "V";
-            this.keyV.Location = new System.Drawing.Point(265, 269);
-            this.keyV.Margin = new System.Windows.Forms.Padding(4);
-            this.keyV.Name = "keyV";
-            this.keyV.Pressed = false;
-            this.keyV.Size = new System.Drawing.Size(40, 40);
-            this.keyV.TabIndex = 58;
-            this.keyV.Tested = false;
+            keyV.Enabled = false;
+            keyV.Legend = "V";
+            keyV.Location = new System.Drawing.Point(309, 310);
+            keyV.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyV.Name = "keyV";
+            keyV.Pressed = false;
+            keyV.Size = new System.Drawing.Size(47, 46);
+            keyV.TabIndex = 58;
+            keyV.Tested = false;
             // 
             // keyB
             // 
-            this.keyB.Enabled = false;
-            this.keyB.Legend = "B";
-            this.keyB.Location = new System.Drawing.Point(313, 269);
-            this.keyB.Margin = new System.Windows.Forms.Padding(4);
-            this.keyB.Name = "keyB";
-            this.keyB.Pressed = false;
-            this.keyB.Size = new System.Drawing.Size(40, 40);
-            this.keyB.TabIndex = 59;
-            this.keyB.Tested = false;
+            keyB.Enabled = false;
+            keyB.Legend = "B";
+            keyB.Location = new System.Drawing.Point(365, 310);
+            keyB.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyB.Name = "keyB";
+            keyB.Pressed = false;
+            keyB.Size = new System.Drawing.Size(47, 46);
+            keyB.TabIndex = 59;
+            keyB.Tested = false;
             // 
             // keyN
             // 
-            this.keyN.Enabled = false;
-            this.keyN.Legend = "N";
-            this.keyN.Location = new System.Drawing.Point(361, 269);
-            this.keyN.Margin = new System.Windows.Forms.Padding(4);
-            this.keyN.Name = "keyN";
-            this.keyN.Pressed = false;
-            this.keyN.Size = new System.Drawing.Size(40, 40);
-            this.keyN.TabIndex = 60;
-            this.keyN.Tested = false;
+            keyN.Enabled = false;
+            keyN.Legend = "N";
+            keyN.Location = new System.Drawing.Point(421, 310);
+            keyN.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyN.Name = "keyN";
+            keyN.Pressed = false;
+            keyN.Size = new System.Drawing.Size(47, 46);
+            keyN.TabIndex = 60;
+            keyN.Tested = false;
             // 
             // keyM
             // 
-            this.keyM.Enabled = false;
-            this.keyM.Legend = "M";
-            this.keyM.Location = new System.Drawing.Point(409, 269);
-            this.keyM.Margin = new System.Windows.Forms.Padding(4);
-            this.keyM.Name = "keyM";
-            this.keyM.Pressed = false;
-            this.keyM.Size = new System.Drawing.Size(40, 40);
-            this.keyM.TabIndex = 61;
-            this.keyM.Tested = false;
+            keyM.Enabled = false;
+            keyM.Legend = "M";
+            keyM.Location = new System.Drawing.Point(477, 310);
+            keyM.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyM.Name = "keyM";
+            keyM.Pressed = false;
+            keyM.Size = new System.Drawing.Size(47, 46);
+            keyM.TabIndex = 61;
+            keyM.Tested = false;
             // 
             // keyEscape
             // 
-            this.keyEscape.Enabled = false;
-            this.keyEscape.Legend = "Esc";
-            this.keyEscape.Location = new System.Drawing.Point(13, 61);
-            this.keyEscape.Margin = new System.Windows.Forms.Padding(4);
-            this.keyEscape.Name = "keyEscape";
-            this.keyEscape.Pressed = false;
-            this.keyEscape.Size = new System.Drawing.Size(40, 40);
-            this.keyEscape.TabIndex = 62;
-            this.keyEscape.Tested = false;
+            keyEscape.Enabled = false;
+            keyEscape.Legend = "Esc";
+            keyEscape.Location = new System.Drawing.Point(15, 70);
+            keyEscape.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEscape.Name = "keyEscape";
+            keyEscape.Pressed = false;
+            keyEscape.Size = new System.Drawing.Size(47, 46);
+            keyEscape.TabIndex = 62;
+            keyEscape.Tested = false;
             // 
             // keyGrave
             // 
-            this.keyGrave.Enabled = false;
-            this.keyGrave.Legend = "~\r\n`";
-            this.keyGrave.Location = new System.Drawing.Point(13, 125);
-            this.keyGrave.Margin = new System.Windows.Forms.Padding(4);
-            this.keyGrave.Name = "keyGrave";
-            this.keyGrave.Pressed = false;
-            this.keyGrave.Size = new System.Drawing.Size(40, 40);
-            this.keyGrave.TabIndex = 63;
-            this.keyGrave.Tested = false;
+            keyGrave.Enabled = false;
+            keyGrave.Legend = "~\r\n`";
+            keyGrave.Location = new System.Drawing.Point(15, 144);
+            keyGrave.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyGrave.Name = "keyGrave";
+            keyGrave.Pressed = false;
+            keyGrave.Size = new System.Drawing.Size(47, 46);
+            keyGrave.TabIndex = 63;
+            keyGrave.Tested = false;
             // 
             // keyMinus
             // 
-            this.keyMinus.Enabled = false;
-            this.keyMinus.Legend = "_\r\n-";
-            this.keyMinus.Location = new System.Drawing.Point(541, 125);
-            this.keyMinus.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMinus.Name = "keyMinus";
-            this.keyMinus.Pressed = false;
-            this.keyMinus.Size = new System.Drawing.Size(40, 40);
-            this.keyMinus.TabIndex = 64;
-            this.keyMinus.Tested = false;
+            keyMinus.Enabled = false;
+            keyMinus.Legend = "_\r\n-";
+            keyMinus.Location = new System.Drawing.Point(631, 144);
+            keyMinus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMinus.Name = "keyMinus";
+            keyMinus.Pressed = false;
+            keyMinus.Size = new System.Drawing.Size(47, 46);
+            keyMinus.TabIndex = 64;
+            keyMinus.Tested = false;
             // 
             // keyEqual
             // 
-            this.keyEqual.Enabled = false;
-            this.keyEqual.Legend = "+\r\n=";
-            this.keyEqual.Location = new System.Drawing.Point(589, 125);
-            this.keyEqual.Margin = new System.Windows.Forms.Padding(4);
-            this.keyEqual.Name = "keyEqual";
-            this.keyEqual.Pressed = false;
-            this.keyEqual.Size = new System.Drawing.Size(40, 40);
-            this.keyEqual.TabIndex = 65;
-            this.keyEqual.Tested = false;
+            keyEqual.Enabled = false;
+            keyEqual.Legend = "+\r\n=";
+            keyEqual.Location = new System.Drawing.Point(687, 144);
+            keyEqual.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEqual.Name = "keyEqual";
+            keyEqual.Pressed = false;
+            keyEqual.Size = new System.Drawing.Size(47, 46);
+            keyEqual.TabIndex = 65;
+            keyEqual.Tested = false;
             // 
             // keyBackspace
             // 
-            this.keyBackspace.Enabled = false;
-            this.keyBackspace.Legend = "Backspace";
-            this.keyBackspace.Location = new System.Drawing.Point(637, 125);
-            this.keyBackspace.Margin = new System.Windows.Forms.Padding(4);
-            this.keyBackspace.Name = "keyBackspace";
-            this.keyBackspace.Pressed = false;
-            this.keyBackspace.Size = new System.Drawing.Size(88, 40);
-            this.keyBackspace.TabIndex = 66;
-            this.keyBackspace.Tested = false;
+            keyBackspace.Enabled = false;
+            keyBackspace.Legend = "Backspace";
+            keyBackspace.Location = new System.Drawing.Point(743, 144);
+            keyBackspace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyBackspace.Name = "keyBackspace";
+            keyBackspace.Pressed = false;
+            keyBackspace.Size = new System.Drawing.Size(103, 46);
+            keyBackspace.TabIndex = 66;
+            keyBackspace.Tested = false;
             // 
             // keyTab
             // 
-            this.keyTab.Enabled = false;
-            this.keyTab.Legend = "Tab";
-            this.keyTab.Location = new System.Drawing.Point(13, 173);
-            this.keyTab.Margin = new System.Windows.Forms.Padding(4);
-            this.keyTab.Name = "keyTab";
-            this.keyTab.Pressed = false;
-            this.keyTab.Size = new System.Drawing.Size(64, 40);
-            this.keyTab.TabIndex = 67;
-            this.keyTab.Tested = false;
+            keyTab.Enabled = false;
+            keyTab.Legend = "Tab";
+            keyTab.Location = new System.Drawing.Point(15, 200);
+            keyTab.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyTab.Name = "keyTab";
+            keyTab.Pressed = false;
+            keyTab.Size = new System.Drawing.Size(75, 46);
+            keyTab.TabIndex = 67;
+            keyTab.Tested = false;
             // 
             // keyLeftBrace
             // 
-            this.keyLeftBrace.Enabled = false;
-            this.keyLeftBrace.Legend = "{\r\n[";
-            this.keyLeftBrace.Location = new System.Drawing.Point(565, 173);
-            this.keyLeftBrace.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeftBrace.Name = "keyLeftBrace";
-            this.keyLeftBrace.Pressed = false;
-            this.keyLeftBrace.Size = new System.Drawing.Size(40, 40);
-            this.keyLeftBrace.TabIndex = 68;
-            this.keyLeftBrace.Tested = false;
+            keyLeftBrace.Enabled = false;
+            keyLeftBrace.Legend = "{\r\n[";
+            keyLeftBrace.Location = new System.Drawing.Point(659, 200);
+            keyLeftBrace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftBrace.Name = "keyLeftBrace";
+            keyLeftBrace.Pressed = false;
+            keyLeftBrace.Size = new System.Drawing.Size(47, 46);
+            keyLeftBrace.TabIndex = 68;
+            keyLeftBrace.Tested = false;
             // 
             // keyRightBrace
             // 
-            this.keyRightBrace.Enabled = false;
-            this.keyRightBrace.Legend = "}\r\n]";
-            this.keyRightBrace.Location = new System.Drawing.Point(613, 173);
-            this.keyRightBrace.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRightBrace.Name = "keyRightBrace";
-            this.keyRightBrace.Pressed = false;
-            this.keyRightBrace.Size = new System.Drawing.Size(40, 40);
-            this.keyRightBrace.TabIndex = 69;
-            this.keyRightBrace.Tested = false;
+            keyRightBrace.Enabled = false;
+            keyRightBrace.Legend = "}\r\n]";
+            keyRightBrace.Location = new System.Drawing.Point(715, 200);
+            keyRightBrace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightBrace.Name = "keyRightBrace";
+            keyRightBrace.Pressed = false;
+            keyRightBrace.Size = new System.Drawing.Size(47, 46);
+            keyRightBrace.TabIndex = 69;
+            keyRightBrace.Tested = false;
             // 
             // keyBackslash
             // 
-            this.keyBackslash.Enabled = false;
-            this.keyBackslash.Legend = "|\r\n\\";
-            this.keyBackslash.Location = new System.Drawing.Point(661, 173);
-            this.keyBackslash.Margin = new System.Windows.Forms.Padding(4);
-            this.keyBackslash.Name = "keyBackslash";
-            this.keyBackslash.Pressed = false;
-            this.keyBackslash.Size = new System.Drawing.Size(64, 40);
-            this.keyBackslash.TabIndex = 70;
-            this.keyBackslash.Tested = false;
+            keyBackslash.Enabled = false;
+            keyBackslash.Legend = "|\r\n\\";
+            keyBackslash.Location = new System.Drawing.Point(771, 200);
+            keyBackslash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyBackslash.Name = "keyBackslash";
+            keyBackslash.Pressed = false;
+            keyBackslash.Size = new System.Drawing.Size(75, 46);
+            keyBackslash.TabIndex = 70;
+            keyBackslash.Tested = false;
             // 
             // keyCapsLock
             // 
-            this.keyCapsLock.Enabled = false;
-            this.keyCapsLock.Legend = "Caps Lock";
-            this.keyCapsLock.Location = new System.Drawing.Point(13, 221);
-            this.keyCapsLock.Margin = new System.Windows.Forms.Padding(4);
-            this.keyCapsLock.Name = "keyCapsLock";
-            this.keyCapsLock.Pressed = false;
-            this.keyCapsLock.Size = new System.Drawing.Size(76, 40);
-            this.keyCapsLock.TabIndex = 71;
-            this.keyCapsLock.Tested = false;
+            keyCapsLock.Enabled = false;
+            keyCapsLock.Legend = "Caps Lock";
+            keyCapsLock.Location = new System.Drawing.Point(15, 255);
+            keyCapsLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyCapsLock.Name = "keyCapsLock";
+            keyCapsLock.Pressed = false;
+            keyCapsLock.Size = new System.Drawing.Size(89, 46);
+            keyCapsLock.TabIndex = 71;
+            keyCapsLock.Tested = false;
             // 
             // keySemicolon
             // 
-            this.keySemicolon.Enabled = false;
-            this.keySemicolon.Legend = ":\r\n;";
-            this.keySemicolon.Location = new System.Drawing.Point(529, 221);
-            this.keySemicolon.Margin = new System.Windows.Forms.Padding(4);
-            this.keySemicolon.Name = "keySemicolon";
-            this.keySemicolon.Pressed = false;
-            this.keySemicolon.Size = new System.Drawing.Size(40, 40);
-            this.keySemicolon.TabIndex = 72;
-            this.keySemicolon.Tested = false;
+            keySemicolon.Enabled = false;
+            keySemicolon.Legend = ":\r\n;";
+            keySemicolon.Location = new System.Drawing.Point(617, 255);
+            keySemicolon.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySemicolon.Name = "keySemicolon";
+            keySemicolon.Pressed = false;
+            keySemicolon.Size = new System.Drawing.Size(47, 46);
+            keySemicolon.TabIndex = 72;
+            keySemicolon.Tested = false;
             // 
             // keyQuote
             // 
-            this.keyQuote.Enabled = false;
-            this.keyQuote.Legend = "\"\r\n\'";
-            this.keyQuote.Location = new System.Drawing.Point(577, 221);
-            this.keyQuote.Margin = new System.Windows.Forms.Padding(4);
-            this.keyQuote.Name = "keyQuote";
-            this.keyQuote.Pressed = false;
-            this.keyQuote.Size = new System.Drawing.Size(40, 40);
-            this.keyQuote.TabIndex = 73;
-            this.keyQuote.Tested = false;
+            keyQuote.Enabled = false;
+            keyQuote.Legend = "\"\r\n'";
+            keyQuote.Location = new System.Drawing.Point(673, 255);
+            keyQuote.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyQuote.Name = "keyQuote";
+            keyQuote.Pressed = false;
+            keyQuote.Size = new System.Drawing.Size(47, 46);
+            keyQuote.TabIndex = 73;
+            keyQuote.Tested = false;
             // 
             // keyNUHS
             // 
-            this.keyNUHS.Enabled = false;
-            this.keyNUHS.Legend = "~\r\n#";
-            this.keyNUHS.Location = new System.Drawing.Point(625, 221);
-            this.keyNUHS.Margin = new System.Windows.Forms.Padding(4);
-            this.keyNUHS.Name = "keyNUHS";
-            this.keyNUHS.Pressed = false;
-            this.keyNUHS.Size = new System.Drawing.Size(40, 40);
-            this.keyNUHS.TabIndex = 74;
-            this.keyNUHS.Tested = false;
+            keyNUHS.Enabled = false;
+            keyNUHS.Legend = "~\r\n#";
+            keyNUHS.Location = new System.Drawing.Point(729, 255);
+            keyNUHS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNUHS.Name = "keyNUHS";
+            keyNUHS.Pressed = false;
+            keyNUHS.Size = new System.Drawing.Size(47, 46);
+            keyNUHS.TabIndex = 74;
+            keyNUHS.Tested = false;
             // 
             // keyEnter
             // 
-            this.keyEnter.Enabled = false;
-            this.keyEnter.Legend = "Enter";
-            this.keyEnter.Location = new System.Drawing.Point(673, 221);
-            this.keyEnter.Margin = new System.Windows.Forms.Padding(4);
-            this.keyEnter.Name = "keyEnter";
-            this.keyEnter.Pressed = false;
-            this.keyEnter.Size = new System.Drawing.Size(52, 40);
-            this.keyEnter.TabIndex = 75;
-            this.keyEnter.Tested = false;
+            keyEnter.Enabled = false;
+            keyEnter.Legend = "Enter";
+            keyEnter.Location = new System.Drawing.Point(785, 255);
+            keyEnter.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEnter.Name = "keyEnter";
+            keyEnter.Pressed = false;
+            keyEnter.Size = new System.Drawing.Size(61, 46);
+            keyEnter.TabIndex = 75;
+            keyEnter.Tested = false;
             // 
             // keyNUBS
             // 
-            this.keyNUBS.Enabled = false;
-            this.keyNUBS.Legend = "|\r\n\\";
-            this.keyNUBS.Location = new System.Drawing.Point(73, 269);
-            this.keyNUBS.Margin = new System.Windows.Forms.Padding(4);
-            this.keyNUBS.Name = "keyNUBS";
-            this.keyNUBS.Pressed = false;
-            this.keyNUBS.Size = new System.Drawing.Size(40, 40);
-            this.keyNUBS.TabIndex = 76;
-            this.keyNUBS.Tested = false;
+            keyNUBS.Enabled = false;
+            keyNUBS.Legend = "|\r\n\\";
+            keyNUBS.Location = new System.Drawing.Point(85, 310);
+            keyNUBS.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNUBS.Name = "keyNUBS";
+            keyNUBS.Pressed = false;
+            keyNUBS.Size = new System.Drawing.Size(47, 46);
+            keyNUBS.TabIndex = 76;
+            keyNUBS.Tested = false;
             // 
             // keyComma
             // 
-            this.keyComma.Enabled = false;
-            this.keyComma.Legend = "<\r\n,";
-            this.keyComma.Location = new System.Drawing.Point(457, 269);
-            this.keyComma.Margin = new System.Windows.Forms.Padding(4);
-            this.keyComma.Name = "keyComma";
-            this.keyComma.Pressed = false;
-            this.keyComma.Size = new System.Drawing.Size(40, 40);
-            this.keyComma.TabIndex = 77;
-            this.keyComma.Tested = false;
+            keyComma.Enabled = false;
+            keyComma.Legend = "<\r\n,";
+            keyComma.Location = new System.Drawing.Point(533, 310);
+            keyComma.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyComma.Name = "keyComma";
+            keyComma.Pressed = false;
+            keyComma.Size = new System.Drawing.Size(47, 46);
+            keyComma.TabIndex = 77;
+            keyComma.Tested = false;
             // 
             // keyDot
             // 
-            this.keyDot.Enabled = false;
-            this.keyDot.Legend = ">\r\n.";
-            this.keyDot.Location = new System.Drawing.Point(505, 269);
-            this.keyDot.Margin = new System.Windows.Forms.Padding(4);
-            this.keyDot.Name = "keyDot";
-            this.keyDot.Pressed = false;
-            this.keyDot.Size = new System.Drawing.Size(40, 40);
-            this.keyDot.TabIndex = 78;
-            this.keyDot.Tested = false;
+            keyDot.Enabled = false;
+            keyDot.Legend = ">\r\n.";
+            keyDot.Location = new System.Drawing.Point(589, 310);
+            keyDot.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDot.Name = "keyDot";
+            keyDot.Pressed = false;
+            keyDot.Size = new System.Drawing.Size(47, 46);
+            keyDot.TabIndex = 78;
+            keyDot.Tested = false;
             // 
             // keySlash
             // 
-            this.keySlash.Enabled = false;
-            this.keySlash.Legend = "?\r\n/";
-            this.keySlash.Location = new System.Drawing.Point(553, 269);
-            this.keySlash.Margin = new System.Windows.Forms.Padding(4);
-            this.keySlash.Name = "keySlash";
-            this.keySlash.Pressed = false;
-            this.keySlash.Size = new System.Drawing.Size(40, 40);
-            this.keySlash.TabIndex = 79;
-            this.keySlash.Tested = false;
+            keySlash.Enabled = false;
+            keySlash.Legend = "?\r\n/";
+            keySlash.Location = new System.Drawing.Point(645, 310);
+            keySlash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySlash.Name = "keySlash";
+            keySlash.Pressed = false;
+            keySlash.Size = new System.Drawing.Size(47, 46);
+            keySlash.TabIndex = 79;
+            keySlash.Tested = false;
             // 
             // keySpace
             // 
-            this.keySpace.Enabled = false;
-            this.keySpace.Legend = "";
-            this.keySpace.Location = new System.Drawing.Point(193, 317);
-            this.keySpace.Margin = new System.Windows.Forms.Padding(4);
-            this.keySpace.Name = "keySpace";
-            this.keySpace.Pressed = false;
-            this.keySpace.Size = new System.Drawing.Size(292, 40);
-            this.keySpace.TabIndex = 80;
-            this.keySpace.Tested = false;
+            keySpace.Enabled = false;
+            keySpace.Legend = "";
+            keySpace.Location = new System.Drawing.Point(225, 366);
+            keySpace.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keySpace.Name = "keySpace";
+            keySpace.Pressed = false;
+            keySpace.Size = new System.Drawing.Size(341, 46);
+            keySpace.TabIndex = 80;
+            keySpace.Tested = false;
             // 
             // keyMenu
             // 
-            this.keyMenu.Enabled = false;
-            this.keyMenu.Legend = "Menu";
-            this.keyMenu.Location = new System.Drawing.Point(613, 317);
-            this.keyMenu.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMenu.Name = "keyMenu";
-            this.keyMenu.Pressed = false;
-            this.keyMenu.Size = new System.Drawing.Size(52, 40);
-            this.keyMenu.TabIndex = 81;
-            this.keyMenu.Tested = false;
+            keyMenu.Enabled = false;
+            keyMenu.Legend = "Menu";
+            keyMenu.Location = new System.Drawing.Point(715, 366);
+            keyMenu.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMenu.Name = "keyMenu";
+            keyMenu.Pressed = false;
+            keyMenu.Size = new System.Drawing.Size(61, 46);
+            keyMenu.TabIndex = 81;
+            keyMenu.Tested = false;
             // 
             // keyLeftControl
             // 
-            this.keyLeftControl.Enabled = false;
-            this.keyLeftControl.Legend = "Ctrl";
-            this.keyLeftControl.Location = new System.Drawing.Point(13, 317);
-            this.keyLeftControl.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeftControl.Name = "keyLeftControl";
-            this.keyLeftControl.Pressed = false;
-            this.keyLeftControl.Size = new System.Drawing.Size(52, 40);
-            this.keyLeftControl.TabIndex = 82;
-            this.keyLeftControl.Tested = false;
+            keyLeftControl.Enabled = false;
+            keyLeftControl.Legend = "Ctrl";
+            keyLeftControl.Location = new System.Drawing.Point(15, 366);
+            keyLeftControl.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftControl.Name = "keyLeftControl";
+            keyLeftControl.Pressed = false;
+            keyLeftControl.Size = new System.Drawing.Size(61, 46);
+            keyLeftControl.TabIndex = 82;
+            keyLeftControl.Tested = false;
             // 
             // keyLeftShift
             // 
-            this.keyLeftShift.Enabled = false;
-            this.keyLeftShift.Legend = "Shift";
-            this.keyLeftShift.Location = new System.Drawing.Point(13, 269);
-            this.keyLeftShift.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeftShift.Name = "keyLeftShift";
-            this.keyLeftShift.Pressed = false;
-            this.keyLeftShift.Size = new System.Drawing.Size(52, 40);
-            this.keyLeftShift.TabIndex = 83;
-            this.keyLeftShift.Tested = false;
+            keyLeftShift.Enabled = false;
+            keyLeftShift.Legend = "Shift";
+            keyLeftShift.Location = new System.Drawing.Point(15, 310);
+            keyLeftShift.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftShift.Name = "keyLeftShift";
+            keyLeftShift.Pressed = false;
+            keyLeftShift.Size = new System.Drawing.Size(61, 46);
+            keyLeftShift.TabIndex = 83;
+            keyLeftShift.Tested = false;
             // 
             // keyLeftAlt
             // 
-            this.keyLeftAlt.Enabled = false;
-            this.keyLeftAlt.Legend = "Alt";
-            this.keyLeftAlt.Location = new System.Drawing.Point(133, 317);
-            this.keyLeftAlt.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeftAlt.Name = "keyLeftAlt";
-            this.keyLeftAlt.Pressed = false;
-            this.keyLeftAlt.Size = new System.Drawing.Size(52, 40);
-            this.keyLeftAlt.TabIndex = 84;
-            this.keyLeftAlt.Tested = false;
+            keyLeftAlt.Enabled = false;
+            keyLeftAlt.Legend = "Alt";
+            keyLeftAlt.Location = new System.Drawing.Point(155, 366);
+            keyLeftAlt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftAlt.Name = "keyLeftAlt";
+            keyLeftAlt.Pressed = false;
+            keyLeftAlt.Size = new System.Drawing.Size(61, 46);
+            keyLeftAlt.TabIndex = 84;
+            keyLeftAlt.Tested = false;
             // 
             // keyLeftGUI
             // 
-            this.keyLeftGUI.Enabled = false;
-            this.keyLeftGUI.Legend = "Win";
-            this.keyLeftGUI.Location = new System.Drawing.Point(73, 317);
-            this.keyLeftGUI.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeftGUI.Name = "keyLeftGUI";
-            this.keyLeftGUI.Pressed = false;
-            this.keyLeftGUI.Size = new System.Drawing.Size(52, 40);
-            this.keyLeftGUI.TabIndex = 85;
-            this.keyLeftGUI.Tested = false;
+            keyLeftGUI.Enabled = false;
+            keyLeftGUI.Legend = "Win";
+            keyLeftGUI.Location = new System.Drawing.Point(85, 366);
+            keyLeftGUI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeftGUI.Name = "keyLeftGUI";
+            keyLeftGUI.Pressed = false;
+            keyLeftGUI.Size = new System.Drawing.Size(61, 46);
+            keyLeftGUI.TabIndex = 85;
+            keyLeftGUI.Tested = false;
             // 
             // keyRightControl
             // 
-            this.keyRightControl.Enabled = false;
-            this.keyRightControl.Legend = "Ctrl";
-            this.keyRightControl.Location = new System.Drawing.Point(673, 317);
-            this.keyRightControl.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRightControl.Name = "keyRightControl";
-            this.keyRightControl.Pressed = false;
-            this.keyRightControl.Size = new System.Drawing.Size(52, 40);
-            this.keyRightControl.TabIndex = 86;
-            this.keyRightControl.Tested = false;
+            keyRightControl.Enabled = false;
+            keyRightControl.Legend = "Ctrl";
+            keyRightControl.Location = new System.Drawing.Point(785, 366);
+            keyRightControl.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightControl.Name = "keyRightControl";
+            keyRightControl.Pressed = false;
+            keyRightControl.Size = new System.Drawing.Size(61, 46);
+            keyRightControl.TabIndex = 86;
+            keyRightControl.Tested = false;
             // 
             // keyRightShift
             // 
-            this.keyRightShift.Enabled = false;
-            this.keyRightShift.Legend = "Shift";
-            this.keyRightShift.Location = new System.Drawing.Point(601, 269);
-            this.keyRightShift.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRightShift.Name = "keyRightShift";
-            this.keyRightShift.Pressed = false;
-            this.keyRightShift.Size = new System.Drawing.Size(124, 40);
-            this.keyRightShift.TabIndex = 87;
-            this.keyRightShift.Tested = false;
+            keyRightShift.Enabled = false;
+            keyRightShift.Legend = "Shift";
+            keyRightShift.Location = new System.Drawing.Point(701, 310);
+            keyRightShift.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightShift.Name = "keyRightShift";
+            keyRightShift.Pressed = false;
+            keyRightShift.Size = new System.Drawing.Size(145, 46);
+            keyRightShift.TabIndex = 87;
+            keyRightShift.Tested = false;
             // 
             // keyRightAlt
             // 
-            this.keyRightAlt.Enabled = false;
-            this.keyRightAlt.Legend = "Alt";
-            this.keyRightAlt.Location = new System.Drawing.Point(493, 317);
-            this.keyRightAlt.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRightAlt.Name = "keyRightAlt";
-            this.keyRightAlt.Pressed = false;
-            this.keyRightAlt.Size = new System.Drawing.Size(52, 40);
-            this.keyRightAlt.TabIndex = 88;
-            this.keyRightAlt.Tested = false;
+            keyRightAlt.Enabled = false;
+            keyRightAlt.Legend = "Alt";
+            keyRightAlt.Location = new System.Drawing.Point(575, 366);
+            keyRightAlt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightAlt.Name = "keyRightAlt";
+            keyRightAlt.Pressed = false;
+            keyRightAlt.Size = new System.Drawing.Size(61, 46);
+            keyRightAlt.TabIndex = 88;
+            keyRightAlt.Tested = false;
             // 
             // keyRightGUI
             // 
-            this.keyRightGUI.Enabled = false;
-            this.keyRightGUI.Legend = "Win";
-            this.keyRightGUI.Location = new System.Drawing.Point(553, 317);
-            this.keyRightGUI.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRightGUI.Name = "keyRightGUI";
-            this.keyRightGUI.Pressed = false;
-            this.keyRightGUI.Size = new System.Drawing.Size(52, 40);
-            this.keyRightGUI.TabIndex = 89;
-            this.keyRightGUI.Tested = false;
+            keyRightGUI.Enabled = false;
+            keyRightGUI.Legend = "Win";
+            keyRightGUI.Location = new System.Drawing.Point(645, 366);
+            keyRightGUI.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRightGUI.Name = "keyRightGUI";
+            keyRightGUI.Pressed = false;
+            keyRightGUI.Size = new System.Drawing.Size(61, 46);
+            keyRightGUI.TabIndex = 89;
+            keyRightGUI.Tested = false;
             // 
             // keyPrintScreen
             // 
-            this.keyPrintScreen.Enabled = false;
-            this.keyPrintScreen.Legend = "Print\r\nScrn";
-            this.keyPrintScreen.Location = new System.Drawing.Point(741, 61);
-            this.keyPrintScreen.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPrintScreen.Name = "keyPrintScreen";
-            this.keyPrintScreen.Pressed = false;
-            this.keyPrintScreen.Size = new System.Drawing.Size(40, 40);
-            this.keyPrintScreen.TabIndex = 90;
-            this.keyPrintScreen.Tested = false;
+            keyPrintScreen.Enabled = false;
+            keyPrintScreen.Legend = "Print\r\nScrn";
+            keyPrintScreen.Location = new System.Drawing.Point(864, 70);
+            keyPrintScreen.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPrintScreen.Name = "keyPrintScreen";
+            keyPrintScreen.Pressed = false;
+            keyPrintScreen.Size = new System.Drawing.Size(47, 46);
+            keyPrintScreen.TabIndex = 90;
+            keyPrintScreen.Tested = false;
             // 
             // keyScrollLock
             // 
-            this.keyScrollLock.Enabled = false;
-            this.keyScrollLock.Legend = "Scroll\r\nLock";
-            this.keyScrollLock.Location = new System.Drawing.Point(789, 61);
-            this.keyScrollLock.Margin = new System.Windows.Forms.Padding(4);
-            this.keyScrollLock.Name = "keyScrollLock";
-            this.keyScrollLock.Pressed = false;
-            this.keyScrollLock.Size = new System.Drawing.Size(40, 40);
-            this.keyScrollLock.TabIndex = 91;
-            this.keyScrollLock.Tested = false;
+            keyScrollLock.Enabled = false;
+            keyScrollLock.Legend = "Scroll\r\nLock";
+            keyScrollLock.Location = new System.Drawing.Point(920, 70);
+            keyScrollLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyScrollLock.Name = "keyScrollLock";
+            keyScrollLock.Pressed = false;
+            keyScrollLock.Size = new System.Drawing.Size(47, 46);
+            keyScrollLock.TabIndex = 91;
+            keyScrollLock.Tested = false;
             // 
             // keyPauseBreak
             // 
-            this.keyPauseBreak.Enabled = false;
-            this.keyPauseBreak.Legend = "Pause";
-            this.keyPauseBreak.Location = new System.Drawing.Point(837, 61);
-            this.keyPauseBreak.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPauseBreak.Name = "keyPauseBreak";
-            this.keyPauseBreak.Pressed = false;
-            this.keyPauseBreak.Size = new System.Drawing.Size(40, 40);
-            this.keyPauseBreak.TabIndex = 92;
-            this.keyPauseBreak.Tested = false;
+            keyPauseBreak.Enabled = false;
+            keyPauseBreak.Legend = "Pause";
+            keyPauseBreak.Location = new System.Drawing.Point(976, 70);
+            keyPauseBreak.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPauseBreak.Name = "keyPauseBreak";
+            keyPauseBreak.Pressed = false;
+            keyPauseBreak.Size = new System.Drawing.Size(47, 46);
+            keyPauseBreak.TabIndex = 92;
+            keyPauseBreak.Tested = false;
             // 
             // keyInsert
             // 
-            this.keyInsert.Enabled = false;
-            this.keyInsert.Legend = "Insert";
-            this.keyInsert.Location = new System.Drawing.Point(741, 125);
-            this.keyInsert.Margin = new System.Windows.Forms.Padding(4);
-            this.keyInsert.Name = "keyInsert";
-            this.keyInsert.Pressed = false;
-            this.keyInsert.Size = new System.Drawing.Size(40, 40);
-            this.keyInsert.TabIndex = 93;
-            this.keyInsert.Tested = false;
+            keyInsert.Enabled = false;
+            keyInsert.Legend = "Insert";
+            keyInsert.Location = new System.Drawing.Point(864, 144);
+            keyInsert.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyInsert.Name = "keyInsert";
+            keyInsert.Pressed = false;
+            keyInsert.Size = new System.Drawing.Size(47, 46);
+            keyInsert.TabIndex = 93;
+            keyInsert.Tested = false;
             // 
             // keyHome
             // 
-            this.keyHome.Enabled = false;
-            this.keyHome.Legend = "Home";
-            this.keyHome.Location = new System.Drawing.Point(789, 125);
-            this.keyHome.Margin = new System.Windows.Forms.Padding(4);
-            this.keyHome.Name = "keyHome";
-            this.keyHome.Pressed = false;
-            this.keyHome.Size = new System.Drawing.Size(40, 40);
-            this.keyHome.TabIndex = 94;
-            this.keyHome.Tested = false;
+            keyHome.Enabled = false;
+            keyHome.Legend = "Home";
+            keyHome.Location = new System.Drawing.Point(920, 144);
+            keyHome.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyHome.Name = "keyHome";
+            keyHome.Pressed = false;
+            keyHome.Size = new System.Drawing.Size(47, 46);
+            keyHome.TabIndex = 94;
+            keyHome.Tested = false;
             // 
             // keyPageUp
             // 
-            this.keyPageUp.Enabled = false;
-            this.keyPageUp.Legend = "Page\r\nUp";
-            this.keyPageUp.Location = new System.Drawing.Point(837, 125);
-            this.keyPageUp.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPageUp.Name = "keyPageUp";
-            this.keyPageUp.Pressed = false;
-            this.keyPageUp.Size = new System.Drawing.Size(40, 40);
-            this.keyPageUp.TabIndex = 95;
-            this.keyPageUp.Tested = false;
+            keyPageUp.Enabled = false;
+            keyPageUp.Legend = "Page\r\nUp";
+            keyPageUp.Location = new System.Drawing.Point(976, 144);
+            keyPageUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPageUp.Name = "keyPageUp";
+            keyPageUp.Pressed = false;
+            keyPageUp.Size = new System.Drawing.Size(47, 46);
+            keyPageUp.TabIndex = 95;
+            keyPageUp.Tested = false;
             // 
             // keyDelete
             // 
-            this.keyDelete.Enabled = false;
-            this.keyDelete.Legend = "Delete";
-            this.keyDelete.Location = new System.Drawing.Point(741, 173);
-            this.keyDelete.Margin = new System.Windows.Forms.Padding(4);
-            this.keyDelete.Name = "keyDelete";
-            this.keyDelete.Pressed = false;
-            this.keyDelete.Size = new System.Drawing.Size(40, 40);
-            this.keyDelete.TabIndex = 96;
-            this.keyDelete.Tested = false;
+            keyDelete.Enabled = false;
+            keyDelete.Legend = "Delete";
+            keyDelete.Location = new System.Drawing.Point(864, 200);
+            keyDelete.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDelete.Name = "keyDelete";
+            keyDelete.Pressed = false;
+            keyDelete.Size = new System.Drawing.Size(47, 46);
+            keyDelete.TabIndex = 96;
+            keyDelete.Tested = false;
             // 
             // keyEnd
             // 
-            this.keyEnd.Enabled = false;
-            this.keyEnd.Legend = "End";
-            this.keyEnd.Location = new System.Drawing.Point(789, 173);
-            this.keyEnd.Margin = new System.Windows.Forms.Padding(4);
-            this.keyEnd.Name = "keyEnd";
-            this.keyEnd.Pressed = false;
-            this.keyEnd.Size = new System.Drawing.Size(40, 40);
-            this.keyEnd.TabIndex = 97;
-            this.keyEnd.Tested = false;
+            keyEnd.Enabled = false;
+            keyEnd.Legend = "End";
+            keyEnd.Location = new System.Drawing.Point(920, 200);
+            keyEnd.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyEnd.Name = "keyEnd";
+            keyEnd.Pressed = false;
+            keyEnd.Size = new System.Drawing.Size(47, 46);
+            keyEnd.TabIndex = 97;
+            keyEnd.Tested = false;
             // 
             // keyPageDown
             // 
-            this.keyPageDown.Enabled = false;
-            this.keyPageDown.Legend = "Page\r\nDown";
-            this.keyPageDown.Location = new System.Drawing.Point(837, 173);
-            this.keyPageDown.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPageDown.Name = "keyPageDown";
-            this.keyPageDown.Pressed = false;
-            this.keyPageDown.Size = new System.Drawing.Size(40, 40);
-            this.keyPageDown.TabIndex = 98;
-            this.keyPageDown.Tested = false;
+            keyPageDown.Enabled = false;
+            keyPageDown.Legend = "Page\r\nDown";
+            keyPageDown.Location = new System.Drawing.Point(976, 200);
+            keyPageDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPageDown.Name = "keyPageDown";
+            keyPageDown.Pressed = false;
+            keyPageDown.Size = new System.Drawing.Size(47, 46);
+            keyPageDown.TabIndex = 98;
+            keyPageDown.Tested = false;
             // 
             // keyUp
             // 
-            this.keyUp.Enabled = false;
-            this.keyUp.Legend = "▴";
-            this.keyUp.Location = new System.Drawing.Point(789, 269);
-            this.keyUp.Margin = new System.Windows.Forms.Padding(4);
-            this.keyUp.Name = "keyUp";
-            this.keyUp.Pressed = false;
-            this.keyUp.Size = new System.Drawing.Size(40, 40);
-            this.keyUp.TabIndex = 99;
-            this.keyUp.Tested = false;
+            keyUp.Enabled = false;
+            keyUp.Legend = "▴";
+            keyUp.Location = new System.Drawing.Point(920, 310);
+            keyUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyUp.Name = "keyUp";
+            keyUp.Pressed = false;
+            keyUp.Size = new System.Drawing.Size(47, 46);
+            keyUp.TabIndex = 99;
+            keyUp.Tested = false;
             // 
             // keyLeft
             // 
-            this.keyLeft.Enabled = false;
-            this.keyLeft.Legend = "◂";
-            this.keyLeft.Location = new System.Drawing.Point(741, 317);
-            this.keyLeft.Margin = new System.Windows.Forms.Padding(4);
-            this.keyLeft.Name = "keyLeft";
-            this.keyLeft.Pressed = false;
-            this.keyLeft.Size = new System.Drawing.Size(40, 40);
-            this.keyLeft.TabIndex = 100;
-            this.keyLeft.Tested = false;
+            keyLeft.Enabled = false;
+            keyLeft.Legend = "◂";
+            keyLeft.Location = new System.Drawing.Point(864, 366);
+            keyLeft.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyLeft.Name = "keyLeft";
+            keyLeft.Pressed = false;
+            keyLeft.Size = new System.Drawing.Size(47, 46);
+            keyLeft.TabIndex = 100;
+            keyLeft.Tested = false;
             // 
             // keyDown
             // 
-            this.keyDown.Enabled = false;
-            this.keyDown.Legend = "▾";
-            this.keyDown.Location = new System.Drawing.Point(789, 317);
-            this.keyDown.Margin = new System.Windows.Forms.Padding(4);
-            this.keyDown.Name = "keyDown";
-            this.keyDown.Pressed = false;
-            this.keyDown.Size = new System.Drawing.Size(40, 40);
-            this.keyDown.TabIndex = 101;
-            this.keyDown.Tested = false;
+            keyDown.Enabled = false;
+            keyDown.Legend = "▾";
+            keyDown.Location = new System.Drawing.Point(920, 366);
+            keyDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyDown.Name = "keyDown";
+            keyDown.Pressed = false;
+            keyDown.Size = new System.Drawing.Size(47, 46);
+            keyDown.TabIndex = 101;
+            keyDown.Tested = false;
             // 
             // keyRight
             // 
-            this.keyRight.Enabled = false;
-            this.keyRight.Legend = "▸";
-            this.keyRight.Location = new System.Drawing.Point(837, 317);
-            this.keyRight.Margin = new System.Windows.Forms.Padding(4);
-            this.keyRight.Name = "keyRight";
-            this.keyRight.Pressed = false;
-            this.keyRight.Size = new System.Drawing.Size(40, 40);
-            this.keyRight.TabIndex = 102;
-            this.keyRight.Tested = false;
+            keyRight.Enabled = false;
+            keyRight.Legend = "▸";
+            keyRight.Location = new System.Drawing.Point(976, 366);
+            keyRight.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyRight.Name = "keyRight";
+            keyRight.Pressed = false;
+            keyRight.Size = new System.Drawing.Size(47, 46);
+            keyRight.TabIndex = 102;
+            keyRight.Tested = false;
             // 
             // keyNumLock
             // 
-            this.keyNumLock.Enabled = false;
-            this.keyNumLock.Legend = "Num\r\nLock";
-            this.keyNumLock.Location = new System.Drawing.Point(893, 125);
-            this.keyNumLock.Margin = new System.Windows.Forms.Padding(4);
-            this.keyNumLock.Name = "keyNumLock";
-            this.keyNumLock.Pressed = false;
-            this.keyNumLock.Size = new System.Drawing.Size(40, 40);
-            this.keyNumLock.TabIndex = 103;
-            this.keyNumLock.Tested = false;
+            keyNumLock.Enabled = false;
+            keyNumLock.Legend = "Num\r\nLock";
+            keyNumLock.Location = new System.Drawing.Point(1042, 144);
+            keyNumLock.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyNumLock.Name = "keyNumLock";
+            keyNumLock.Pressed = false;
+            keyNumLock.Size = new System.Drawing.Size(47, 46);
+            keyNumLock.TabIndex = 103;
+            keyNumLock.Tested = false;
             // 
             // keyPadSlash
             // 
-            this.keyPadSlash.Enabled = false;
-            this.keyPadSlash.Legend = "/";
-            this.keyPadSlash.Location = new System.Drawing.Point(941, 125);
-            this.keyPadSlash.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadSlash.Name = "keyPadSlash";
-            this.keyPadSlash.Pressed = false;
-            this.keyPadSlash.Size = new System.Drawing.Size(40, 40);
-            this.keyPadSlash.TabIndex = 104;
-            this.keyPadSlash.Tested = false;
+            keyPadSlash.Enabled = false;
+            keyPadSlash.Legend = "/";
+            keyPadSlash.Location = new System.Drawing.Point(1098, 144);
+            keyPadSlash.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadSlash.Name = "keyPadSlash";
+            keyPadSlash.Pressed = false;
+            keyPadSlash.Size = new System.Drawing.Size(47, 46);
+            keyPadSlash.TabIndex = 104;
+            keyPadSlash.Tested = false;
             // 
             // keyPadAsterisk
             // 
-            this.keyPadAsterisk.Enabled = false;
-            this.keyPadAsterisk.Legend = "*";
-            this.keyPadAsterisk.Location = new System.Drawing.Point(989, 125);
-            this.keyPadAsterisk.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadAsterisk.Name = "keyPadAsterisk";
-            this.keyPadAsterisk.Pressed = false;
-            this.keyPadAsterisk.Size = new System.Drawing.Size(40, 40);
-            this.keyPadAsterisk.TabIndex = 105;
-            this.keyPadAsterisk.Tested = false;
+            keyPadAsterisk.Enabled = false;
+            keyPadAsterisk.Legend = "*";
+            keyPadAsterisk.Location = new System.Drawing.Point(1154, 144);
+            keyPadAsterisk.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadAsterisk.Name = "keyPadAsterisk";
+            keyPadAsterisk.Pressed = false;
+            keyPadAsterisk.Size = new System.Drawing.Size(47, 46);
+            keyPadAsterisk.TabIndex = 105;
+            keyPadAsterisk.Tested = false;
             // 
             // keyPadMinus
             // 
-            this.keyPadMinus.Enabled = false;
-            this.keyPadMinus.Legend = "-";
-            this.keyPadMinus.Location = new System.Drawing.Point(1037, 125);
-            this.keyPadMinus.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadMinus.Name = "keyPadMinus";
-            this.keyPadMinus.Pressed = false;
-            this.keyPadMinus.Size = new System.Drawing.Size(40, 40);
-            this.keyPadMinus.TabIndex = 106;
-            this.keyPadMinus.Tested = false;
+            keyPadMinus.Enabled = false;
+            keyPadMinus.Legend = "-";
+            keyPadMinus.Location = new System.Drawing.Point(1210, 144);
+            keyPadMinus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadMinus.Name = "keyPadMinus";
+            keyPadMinus.Pressed = false;
+            keyPadMinus.Size = new System.Drawing.Size(47, 46);
+            keyPadMinus.TabIndex = 106;
+            keyPadMinus.Tested = false;
             // 
             // keyPadPlus
             // 
-            this.keyPadPlus.Enabled = false;
-            this.keyPadPlus.Legend = "+";
-            this.keyPadPlus.Location = new System.Drawing.Point(1037, 173);
-            this.keyPadPlus.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadPlus.Name = "keyPadPlus";
-            this.keyPadPlus.Pressed = false;
-            this.keyPadPlus.Size = new System.Drawing.Size(40, 88);
-            this.keyPadPlus.TabIndex = 107;
-            this.keyPadPlus.Tested = false;
+            keyPadPlus.Enabled = false;
+            keyPadPlus.Legend = "+";
+            keyPadPlus.Location = new System.Drawing.Point(1210, 200);
+            keyPadPlus.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadPlus.Name = "keyPadPlus";
+            keyPadPlus.Pressed = false;
+            keyPadPlus.Size = new System.Drawing.Size(47, 102);
+            keyPadPlus.TabIndex = 107;
+            keyPadPlus.Tested = false;
             // 
             // keyPadEnter
             // 
-            this.keyPadEnter.Enabled = false;
-            this.keyPadEnter.Legend = "Ent";
-            this.keyPadEnter.Location = new System.Drawing.Point(1037, 269);
-            this.keyPadEnter.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadEnter.Name = "keyPadEnter";
-            this.keyPadEnter.Pressed = false;
-            this.keyPadEnter.Size = new System.Drawing.Size(40, 88);
-            this.keyPadEnter.TabIndex = 108;
-            this.keyPadEnter.Tested = false;
+            keyPadEnter.Enabled = false;
+            keyPadEnter.Legend = "Ent";
+            keyPadEnter.Location = new System.Drawing.Point(1210, 310);
+            keyPadEnter.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadEnter.Name = "keyPadEnter";
+            keyPadEnter.Pressed = false;
+            keyPadEnter.Size = new System.Drawing.Size(47, 102);
+            keyPadEnter.TabIndex = 108;
+            keyPadEnter.Tested = false;
             // 
             // keyPadDot
             // 
-            this.keyPadDot.Enabled = false;
-            this.keyPadDot.Legend = ".";
-            this.keyPadDot.Location = new System.Drawing.Point(989, 317);
-            this.keyPadDot.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPadDot.Name = "keyPadDot";
-            this.keyPadDot.Pressed = false;
-            this.keyPadDot.Size = new System.Drawing.Size(40, 40);
-            this.keyPadDot.TabIndex = 109;
-            this.keyPadDot.Tested = false;
+            keyPadDot.Enabled = false;
+            keyPadDot.Legend = ".";
+            keyPadDot.Location = new System.Drawing.Point(1154, 366);
+            keyPadDot.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPadDot.Name = "keyPadDot";
+            keyPadDot.Pressed = false;
+            keyPadDot.Size = new System.Drawing.Size(47, 46);
+            keyPadDot.TabIndex = 109;
+            keyPadDot.Tested = false;
             // 
             // keyPad0
             // 
-            this.keyPad0.Enabled = false;
-            this.keyPad0.Legend = "0";
-            this.keyPad0.Location = new System.Drawing.Point(893, 317);
-            this.keyPad0.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad0.Name = "keyPad0";
-            this.keyPad0.Pressed = false;
-            this.keyPad0.Size = new System.Drawing.Size(88, 40);
-            this.keyPad0.TabIndex = 110;
-            this.keyPad0.Tested = false;
+            keyPad0.Enabled = false;
+            keyPad0.Legend = "0";
+            keyPad0.Location = new System.Drawing.Point(1042, 366);
+            keyPad0.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad0.Name = "keyPad0";
+            keyPad0.Pressed = false;
+            keyPad0.Size = new System.Drawing.Size(103, 46);
+            keyPad0.TabIndex = 110;
+            keyPad0.Tested = false;
             // 
             // keyPad1
             // 
-            this.keyPad1.Enabled = false;
-            this.keyPad1.Legend = "1";
-            this.keyPad1.Location = new System.Drawing.Point(893, 269);
-            this.keyPad1.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad1.Name = "keyPad1";
-            this.keyPad1.Pressed = false;
-            this.keyPad1.Size = new System.Drawing.Size(40, 40);
-            this.keyPad1.TabIndex = 111;
-            this.keyPad1.Tested = false;
+            keyPad1.Enabled = false;
+            keyPad1.Legend = "1";
+            keyPad1.Location = new System.Drawing.Point(1042, 310);
+            keyPad1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad1.Name = "keyPad1";
+            keyPad1.Pressed = false;
+            keyPad1.Size = new System.Drawing.Size(47, 46);
+            keyPad1.TabIndex = 111;
+            keyPad1.Tested = false;
             // 
             // keyPad2
             // 
-            this.keyPad2.Enabled = false;
-            this.keyPad2.Legend = "2";
-            this.keyPad2.Location = new System.Drawing.Point(941, 269);
-            this.keyPad2.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad2.Name = "keyPad2";
-            this.keyPad2.Pressed = false;
-            this.keyPad2.Size = new System.Drawing.Size(40, 40);
-            this.keyPad2.TabIndex = 112;
-            this.keyPad2.Tested = false;
+            keyPad2.Enabled = false;
+            keyPad2.Legend = "2";
+            keyPad2.Location = new System.Drawing.Point(1098, 310);
+            keyPad2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad2.Name = "keyPad2";
+            keyPad2.Pressed = false;
+            keyPad2.Size = new System.Drawing.Size(47, 46);
+            keyPad2.TabIndex = 112;
+            keyPad2.Tested = false;
             // 
             // keyPad3
             // 
-            this.keyPad3.Enabled = false;
-            this.keyPad3.Legend = "3";
-            this.keyPad3.Location = new System.Drawing.Point(989, 269);
-            this.keyPad3.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad3.Name = "keyPad3";
-            this.keyPad3.Pressed = false;
-            this.keyPad3.Size = new System.Drawing.Size(40, 40);
-            this.keyPad3.TabIndex = 113;
-            this.keyPad3.Tested = false;
+            keyPad3.Enabled = false;
+            keyPad3.Legend = "3";
+            keyPad3.Location = new System.Drawing.Point(1154, 310);
+            keyPad3.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad3.Name = "keyPad3";
+            keyPad3.Pressed = false;
+            keyPad3.Size = new System.Drawing.Size(47, 46);
+            keyPad3.TabIndex = 113;
+            keyPad3.Tested = false;
             // 
             // keyPad4
             // 
-            this.keyPad4.Enabled = false;
-            this.keyPad4.Legend = "4";
-            this.keyPad4.Location = new System.Drawing.Point(893, 221);
-            this.keyPad4.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad4.Name = "keyPad4";
-            this.keyPad4.Pressed = false;
-            this.keyPad4.Size = new System.Drawing.Size(40, 40);
-            this.keyPad4.TabIndex = 114;
-            this.keyPad4.Tested = false;
+            keyPad4.Enabled = false;
+            keyPad4.Legend = "4";
+            keyPad4.Location = new System.Drawing.Point(1042, 255);
+            keyPad4.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad4.Name = "keyPad4";
+            keyPad4.Pressed = false;
+            keyPad4.Size = new System.Drawing.Size(47, 46);
+            keyPad4.TabIndex = 114;
+            keyPad4.Tested = false;
             // 
             // keyPad5
             // 
-            this.keyPad5.Enabled = false;
-            this.keyPad5.Legend = "5";
-            this.keyPad5.Location = new System.Drawing.Point(941, 221);
-            this.keyPad5.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad5.Name = "keyPad5";
-            this.keyPad5.Pressed = false;
-            this.keyPad5.Size = new System.Drawing.Size(40, 40);
-            this.keyPad5.TabIndex = 115;
-            this.keyPad5.Tested = false;
+            keyPad5.Enabled = false;
+            keyPad5.Legend = "5";
+            keyPad5.Location = new System.Drawing.Point(1098, 255);
+            keyPad5.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad5.Name = "keyPad5";
+            keyPad5.Pressed = false;
+            keyPad5.Size = new System.Drawing.Size(47, 46);
+            keyPad5.TabIndex = 115;
+            keyPad5.Tested = false;
             // 
             // keyPad6
             // 
-            this.keyPad6.Enabled = false;
-            this.keyPad6.Legend = "6";
-            this.keyPad6.Location = new System.Drawing.Point(989, 221);
-            this.keyPad6.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad6.Name = "keyPad6";
-            this.keyPad6.Pressed = false;
-            this.keyPad6.Size = new System.Drawing.Size(40, 40);
-            this.keyPad6.TabIndex = 116;
-            this.keyPad6.Tested = false;
+            keyPad6.Enabled = false;
+            keyPad6.Legend = "6";
+            keyPad6.Location = new System.Drawing.Point(1154, 255);
+            keyPad6.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad6.Name = "keyPad6";
+            keyPad6.Pressed = false;
+            keyPad6.Size = new System.Drawing.Size(47, 46);
+            keyPad6.TabIndex = 116;
+            keyPad6.Tested = false;
             // 
             // keyPad7
             // 
-            this.keyPad7.Enabled = false;
-            this.keyPad7.Legend = "7";
-            this.keyPad7.Location = new System.Drawing.Point(893, 173);
-            this.keyPad7.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad7.Name = "keyPad7";
-            this.keyPad7.Pressed = false;
-            this.keyPad7.Size = new System.Drawing.Size(40, 40);
-            this.keyPad7.TabIndex = 117;
-            this.keyPad7.Tested = false;
+            keyPad7.Enabled = false;
+            keyPad7.Legend = "7";
+            keyPad7.Location = new System.Drawing.Point(1042, 200);
+            keyPad7.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad7.Name = "keyPad7";
+            keyPad7.Pressed = false;
+            keyPad7.Size = new System.Drawing.Size(47, 46);
+            keyPad7.TabIndex = 117;
+            keyPad7.Tested = false;
             // 
             // keyPad8
             // 
-            this.keyPad8.Enabled = false;
-            this.keyPad8.Legend = "8";
-            this.keyPad8.Location = new System.Drawing.Point(941, 173);
-            this.keyPad8.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad8.Name = "keyPad8";
-            this.keyPad8.Pressed = false;
-            this.keyPad8.Size = new System.Drawing.Size(40, 40);
-            this.keyPad8.TabIndex = 118;
-            this.keyPad8.Tested = false;
+            keyPad8.Enabled = false;
+            keyPad8.Legend = "8";
+            keyPad8.Location = new System.Drawing.Point(1098, 200);
+            keyPad8.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad8.Name = "keyPad8";
+            keyPad8.Pressed = false;
+            keyPad8.Size = new System.Drawing.Size(47, 46);
+            keyPad8.TabIndex = 118;
+            keyPad8.Tested = false;
             // 
             // keyPad9
             // 
-            this.keyPad9.Enabled = false;
-            this.keyPad9.Legend = "9";
-            this.keyPad9.Location = new System.Drawing.Point(989, 173);
-            this.keyPad9.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPad9.Name = "keyPad9";
-            this.keyPad9.Pressed = false;
-            this.keyPad9.Size = new System.Drawing.Size(40, 40);
-            this.keyPad9.TabIndex = 119;
-            this.keyPad9.Tested = false;
+            keyPad9.Enabled = false;
+            keyPad9.Legend = "9";
+            keyPad9.Location = new System.Drawing.Point(1154, 200);
+            keyPad9.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPad9.Name = "keyPad9";
+            keyPad9.Pressed = false;
+            keyPad9.Size = new System.Drawing.Size(47, 46);
+            keyPad9.TabIndex = 119;
+            keyPad9.Tested = false;
             // 
             // keyMute
             // 
-            this.keyMute.Enabled = false;
-            this.keyMute.Legend = "Mut";
-            this.keyMute.Location = new System.Drawing.Point(893, 13);
-            this.keyMute.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMute.Name = "keyMute";
-            this.keyMute.Pressed = false;
-            this.keyMute.Size = new System.Drawing.Size(40, 40);
-            this.keyMute.TabIndex = 120;
-            this.keyMute.Tested = false;
+            keyMute.Enabled = false;
+            keyMute.Legend = "Mut";
+            keyMute.Location = new System.Drawing.Point(1042, 15);
+            keyMute.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMute.Name = "keyMute";
+            keyMute.Pressed = false;
+            keyMute.Size = new System.Drawing.Size(47, 46);
+            keyMute.TabIndex = 120;
+            keyMute.Tested = false;
             // 
             // keyVolumeDown
             // 
-            this.keyVolumeDown.Enabled = false;
-            this.keyVolumeDown.Legend = "Vol-";
-            this.keyVolumeDown.Location = new System.Drawing.Point(941, 13);
-            this.keyVolumeDown.Margin = new System.Windows.Forms.Padding(4);
-            this.keyVolumeDown.Name = "keyVolumeDown";
-            this.keyVolumeDown.Pressed = false;
-            this.keyVolumeDown.Size = new System.Drawing.Size(40, 40);
-            this.keyVolumeDown.TabIndex = 121;
-            this.keyVolumeDown.Tested = false;
+            keyVolumeDown.Enabled = false;
+            keyVolumeDown.Legend = "Vol-";
+            keyVolumeDown.Location = new System.Drawing.Point(1098, 15);
+            keyVolumeDown.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyVolumeDown.Name = "keyVolumeDown";
+            keyVolumeDown.Pressed = false;
+            keyVolumeDown.Size = new System.Drawing.Size(47, 46);
+            keyVolumeDown.TabIndex = 121;
+            keyVolumeDown.Tested = false;
             // 
             // keyVolumeUp
             // 
-            this.keyVolumeUp.Enabled = false;
-            this.keyVolumeUp.Legend = "Vol+";
-            this.keyVolumeUp.Location = new System.Drawing.Point(989, 13);
-            this.keyVolumeUp.Margin = new System.Windows.Forms.Padding(4);
-            this.keyVolumeUp.Name = "keyVolumeUp";
-            this.keyVolumeUp.Pressed = false;
-            this.keyVolumeUp.Size = new System.Drawing.Size(40, 40);
-            this.keyVolumeUp.TabIndex = 122;
-            this.keyVolumeUp.Tested = false;
+            keyVolumeUp.Enabled = false;
+            keyVolumeUp.Legend = "Vol+";
+            keyVolumeUp.Location = new System.Drawing.Point(1154, 15);
+            keyVolumeUp.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyVolumeUp.Name = "keyVolumeUp";
+            keyVolumeUp.Pressed = false;
+            keyVolumeUp.Size = new System.Drawing.Size(47, 46);
+            keyVolumeUp.TabIndex = 122;
+            keyVolumeUp.Tested = false;
             // 
             // keyPlayPause
             // 
-            this.keyPlayPause.Enabled = false;
-            this.keyPlayPause.Legend = "Play";
-            this.keyPlayPause.Location = new System.Drawing.Point(893, 61);
-            this.keyPlayPause.Margin = new System.Windows.Forms.Padding(4);
-            this.keyPlayPause.Name = "keyPlayPause";
-            this.keyPlayPause.Pressed = false;
-            this.keyPlayPause.Size = new System.Drawing.Size(40, 40);
-            this.keyPlayPause.TabIndex = 123;
-            this.keyPlayPause.Tested = false;
+            keyPlayPause.Enabled = false;
+            keyPlayPause.Legend = "Play";
+            keyPlayPause.Location = new System.Drawing.Point(1042, 70);
+            keyPlayPause.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyPlayPause.Name = "keyPlayPause";
+            keyPlayPause.Pressed = false;
+            keyPlayPause.Size = new System.Drawing.Size(47, 46);
+            keyPlayPause.TabIndex = 123;
+            keyPlayPause.Tested = false;
             // 
             // keyMediaPrevious
             // 
-            this.keyMediaPrevious.Enabled = false;
-            this.keyMediaPrevious.Legend = "Prev";
-            this.keyMediaPrevious.Location = new System.Drawing.Point(941, 61);
-            this.keyMediaPrevious.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMediaPrevious.Name = "keyMediaPrevious";
-            this.keyMediaPrevious.Pressed = false;
-            this.keyMediaPrevious.Size = new System.Drawing.Size(40, 40);
-            this.keyMediaPrevious.TabIndex = 124;
-            this.keyMediaPrevious.Tested = false;
+            keyMediaPrevious.Enabled = false;
+            keyMediaPrevious.Legend = "Prev";
+            keyMediaPrevious.Location = new System.Drawing.Point(1098, 70);
+            keyMediaPrevious.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMediaPrevious.Name = "keyMediaPrevious";
+            keyMediaPrevious.Pressed = false;
+            keyMediaPrevious.Size = new System.Drawing.Size(47, 46);
+            keyMediaPrevious.TabIndex = 124;
+            keyMediaPrevious.Tested = false;
             // 
             // keyMediaNext
             // 
-            this.keyMediaNext.Enabled = false;
-            this.keyMediaNext.Legend = "Next";
-            this.keyMediaNext.Location = new System.Drawing.Point(989, 61);
-            this.keyMediaNext.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMediaNext.Name = "keyMediaNext";
-            this.keyMediaNext.Pressed = false;
-            this.keyMediaNext.Size = new System.Drawing.Size(40, 40);
-            this.keyMediaNext.TabIndex = 125;
-            this.keyMediaNext.Tested = false;
+            keyMediaNext.Enabled = false;
+            keyMediaNext.Legend = "Next";
+            keyMediaNext.Location = new System.Drawing.Point(1154, 70);
+            keyMediaNext.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMediaNext.Name = "keyMediaNext";
+            keyMediaNext.Pressed = false;
+            keyMediaNext.Size = new System.Drawing.Size(47, 46);
+            keyMediaNext.TabIndex = 125;
+            keyMediaNext.Tested = false;
             // 
             // keyMail
             // 
-            this.keyMail.Enabled = false;
-            this.keyMail.Legend = "Mail";
-            this.keyMail.Location = new System.Drawing.Point(1037, 13);
-            this.keyMail.Margin = new System.Windows.Forms.Padding(4);
-            this.keyMail.Name = "keyMail";
-            this.keyMail.Pressed = false;
-            this.keyMail.Size = new System.Drawing.Size(40, 40);
-            this.keyMail.TabIndex = 126;
-            this.keyMail.Tested = false;
+            keyMail.Enabled = false;
+            keyMail.Legend = "Mail";
+            keyMail.Location = new System.Drawing.Point(1210, 15);
+            keyMail.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyMail.Name = "keyMail";
+            keyMail.Pressed = false;
+            keyMail.Size = new System.Drawing.Size(47, 46);
+            keyMail.TabIndex = 126;
+            keyMail.Tested = false;
             // 
             // keyCalculator
             // 
-            this.keyCalculator.Enabled = false;
-            this.keyCalculator.Legend = "Calc";
-            this.keyCalculator.Location = new System.Drawing.Point(1037, 61);
-            this.keyCalculator.Margin = new System.Windows.Forms.Padding(4);
-            this.keyCalculator.Name = "keyCalculator";
-            this.keyCalculator.Pressed = false;
-            this.keyCalculator.Size = new System.Drawing.Size(40, 40);
-            this.keyCalculator.TabIndex = 127;
-            this.keyCalculator.Tested = false;
+            keyCalculator.Enabled = false;
+            keyCalculator.Legend = "Calc";
+            keyCalculator.Location = new System.Drawing.Point(1210, 70);
+            keyCalculator.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            keyCalculator.Name = "keyCalculator";
+            keyCalculator.Pressed = false;
+            keyCalculator.Size = new System.Drawing.Size(47, 46);
+            keyCalculator.TabIndex = 127;
+            keyCalculator.Tested = false;
             // 
             // KeyTesterWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1090, 370);
-            this.Controls.Add(this.lblLastScanCode);
-            this.Controls.Add(this.lblLastVirtualKey);
-            this.Controls.Add(this.keyF1);
-            this.Controls.Add(this.keyF2);
-            this.Controls.Add(this.keyF3);
-            this.Controls.Add(this.keyF4);
-            this.Controls.Add(this.keyF5);
-            this.Controls.Add(this.keyF6);
-            this.Controls.Add(this.keyF7);
-            this.Controls.Add(this.keyF8);
-            this.Controls.Add(this.keyF9);
-            this.Controls.Add(this.keyF10);
-            this.Controls.Add(this.keyF11);
-            this.Controls.Add(this.keyF12);
-            this.Controls.Add(this.keyF13);
-            this.Controls.Add(this.keyF14);
-            this.Controls.Add(this.keyF15);
-            this.Controls.Add(this.keyF16);
-            this.Controls.Add(this.keyF17);
-            this.Controls.Add(this.keyF18);
-            this.Controls.Add(this.keyF19);
-            this.Controls.Add(this.keyF20);
-            this.Controls.Add(this.keyF21);
-            this.Controls.Add(this.keyF22);
-            this.Controls.Add(this.keyF23);
-            this.Controls.Add(this.keyF24);
-            this.Controls.Add(this.key1);
-            this.Controls.Add(this.key2);
-            this.Controls.Add(this.key3);
-            this.Controls.Add(this.key4);
-            this.Controls.Add(this.key5);
-            this.Controls.Add(this.key6);
-            this.Controls.Add(this.key7);
-            this.Controls.Add(this.key8);
-            this.Controls.Add(this.key9);
-            this.Controls.Add(this.key0);
-            this.Controls.Add(this.keyQ);
-            this.Controls.Add(this.keyW);
-            this.Controls.Add(this.keyE);
-            this.Controls.Add(this.keyR);
-            this.Controls.Add(this.keyT);
-            this.Controls.Add(this.keyY);
-            this.Controls.Add(this.keyU);
-            this.Controls.Add(this.keyI);
-            this.Controls.Add(this.keyO);
-            this.Controls.Add(this.keyP);
-            this.Controls.Add(this.keyA);
-            this.Controls.Add(this.keyS);
-            this.Controls.Add(this.keyD);
-            this.Controls.Add(this.keyF);
-            this.Controls.Add(this.keyG);
-            this.Controls.Add(this.keyH);
-            this.Controls.Add(this.keyJ);
-            this.Controls.Add(this.keyK);
-            this.Controls.Add(this.keyL);
-            this.Controls.Add(this.keyZ);
-            this.Controls.Add(this.keyX);
-            this.Controls.Add(this.keyC);
-            this.Controls.Add(this.keyV);
-            this.Controls.Add(this.keyB);
-            this.Controls.Add(this.keyN);
-            this.Controls.Add(this.keyM);
-            this.Controls.Add(this.keyEscape);
-            this.Controls.Add(this.keyGrave);
-            this.Controls.Add(this.keyMinus);
-            this.Controls.Add(this.keyEqual);
-            this.Controls.Add(this.keyBackspace);
-            this.Controls.Add(this.keyTab);
-            this.Controls.Add(this.keyLeftBrace);
-            this.Controls.Add(this.keyRightBrace);
-            this.Controls.Add(this.keyBackslash);
-            this.Controls.Add(this.keyCapsLock);
-            this.Controls.Add(this.keySemicolon);
-            this.Controls.Add(this.keyQuote);
-            this.Controls.Add(this.keyNUHS);
-            this.Controls.Add(this.keyEnter);
-            this.Controls.Add(this.keyNUBS);
-            this.Controls.Add(this.keyComma);
-            this.Controls.Add(this.keyDot);
-            this.Controls.Add(this.keySlash);
-            this.Controls.Add(this.keySpace);
-            this.Controls.Add(this.keyMenu);
-            this.Controls.Add(this.keyLeftControl);
-            this.Controls.Add(this.keyLeftShift);
-            this.Controls.Add(this.keyLeftAlt);
-            this.Controls.Add(this.keyLeftGUI);
-            this.Controls.Add(this.keyRightControl);
-            this.Controls.Add(this.keyRightShift);
-            this.Controls.Add(this.keyRightAlt);
-            this.Controls.Add(this.keyRightGUI);
-            this.Controls.Add(this.keyPrintScreen);
-            this.Controls.Add(this.keyScrollLock);
-            this.Controls.Add(this.keyPauseBreak);
-            this.Controls.Add(this.keyInsert);
-            this.Controls.Add(this.keyHome);
-            this.Controls.Add(this.keyPageUp);
-            this.Controls.Add(this.keyDelete);
-            this.Controls.Add(this.keyEnd);
-            this.Controls.Add(this.keyPageDown);
-            this.Controls.Add(this.keyUp);
-            this.Controls.Add(this.keyLeft);
-            this.Controls.Add(this.keyDown);
-            this.Controls.Add(this.keyRight);
-            this.Controls.Add(this.keyNumLock);
-            this.Controls.Add(this.keyPadSlash);
-            this.Controls.Add(this.keyPadAsterisk);
-            this.Controls.Add(this.keyPadMinus);
-            this.Controls.Add(this.keyPadPlus);
-            this.Controls.Add(this.keyPadEnter);
-            this.Controls.Add(this.keyPadDot);
-            this.Controls.Add(this.keyPad0);
-            this.Controls.Add(this.keyPad1);
-            this.Controls.Add(this.keyPad2);
-            this.Controls.Add(this.keyPad3);
-            this.Controls.Add(this.keyPad4);
-            this.Controls.Add(this.keyPad5);
-            this.Controls.Add(this.keyPad6);
-            this.Controls.Add(this.keyPad7);
-            this.Controls.Add(this.keyPad8);
-            this.Controls.Add(this.keyPad9);
-            this.Controls.Add(this.keyMute);
-            this.Controls.Add(this.keyVolumeDown);
-            this.Controls.Add(this.keyVolumeUp);
-            this.Controls.Add(this.keyPlayPause);
-            this.Controls.Add(this.keyMediaPrevious);
-            this.Controls.Add(this.keyMediaNext);
-            this.Controls.Add(this.keyMail);
-            this.Controls.Add(this.keyCalculator);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.KeyPreview = true;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "KeyTesterWindow";
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Key Tester";
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(1272, 427);
+            Controls.Add(lblLastScanCode);
+            Controls.Add(lblLastVirtualKey);
+            Controls.Add(keyF1);
+            Controls.Add(keyF2);
+            Controls.Add(keyF3);
+            Controls.Add(keyF4);
+            Controls.Add(keyF5);
+            Controls.Add(keyF6);
+            Controls.Add(keyF7);
+            Controls.Add(keyF8);
+            Controls.Add(keyF9);
+            Controls.Add(keyF10);
+            Controls.Add(keyF11);
+            Controls.Add(keyF12);
+            Controls.Add(keyF13);
+            Controls.Add(keyF14);
+            Controls.Add(keyF15);
+            Controls.Add(keyF16);
+            Controls.Add(keyF17);
+            Controls.Add(keyF18);
+            Controls.Add(keyF19);
+            Controls.Add(keyF20);
+            Controls.Add(keyF21);
+            Controls.Add(keyF22);
+            Controls.Add(keyF23);
+            Controls.Add(keyF24);
+            Controls.Add(key1);
+            Controls.Add(key2);
+            Controls.Add(key3);
+            Controls.Add(key4);
+            Controls.Add(key5);
+            Controls.Add(key6);
+            Controls.Add(key7);
+            Controls.Add(key8);
+            Controls.Add(key9);
+            Controls.Add(key0);
+            Controls.Add(keyQ);
+            Controls.Add(keyW);
+            Controls.Add(keyE);
+            Controls.Add(keyR);
+            Controls.Add(keyT);
+            Controls.Add(keyY);
+            Controls.Add(keyU);
+            Controls.Add(keyI);
+            Controls.Add(keyO);
+            Controls.Add(keyP);
+            Controls.Add(keyA);
+            Controls.Add(keyS);
+            Controls.Add(keyD);
+            Controls.Add(keyF);
+            Controls.Add(keyG);
+            Controls.Add(keyH);
+            Controls.Add(keyJ);
+            Controls.Add(keyK);
+            Controls.Add(keyL);
+            Controls.Add(keyZ);
+            Controls.Add(keyX);
+            Controls.Add(keyC);
+            Controls.Add(keyV);
+            Controls.Add(keyB);
+            Controls.Add(keyN);
+            Controls.Add(keyM);
+            Controls.Add(keyEscape);
+            Controls.Add(keyGrave);
+            Controls.Add(keyMinus);
+            Controls.Add(keyEqual);
+            Controls.Add(keyBackspace);
+            Controls.Add(keyTab);
+            Controls.Add(keyLeftBrace);
+            Controls.Add(keyRightBrace);
+            Controls.Add(keyBackslash);
+            Controls.Add(keyCapsLock);
+            Controls.Add(keySemicolon);
+            Controls.Add(keyQuote);
+            Controls.Add(keyNUHS);
+            Controls.Add(keyEnter);
+            Controls.Add(keyNUBS);
+            Controls.Add(keyComma);
+            Controls.Add(keyDot);
+            Controls.Add(keySlash);
+            Controls.Add(keySpace);
+            Controls.Add(keyMenu);
+            Controls.Add(keyLeftControl);
+            Controls.Add(keyLeftShift);
+            Controls.Add(keyLeftAlt);
+            Controls.Add(keyLeftGUI);
+            Controls.Add(keyRightControl);
+            Controls.Add(keyRightShift);
+            Controls.Add(keyRightAlt);
+            Controls.Add(keyRightGUI);
+            Controls.Add(keyPrintScreen);
+            Controls.Add(keyScrollLock);
+            Controls.Add(keyPauseBreak);
+            Controls.Add(keyInsert);
+            Controls.Add(keyHome);
+            Controls.Add(keyPageUp);
+            Controls.Add(keyDelete);
+            Controls.Add(keyEnd);
+            Controls.Add(keyPageDown);
+            Controls.Add(keyUp);
+            Controls.Add(keyLeft);
+            Controls.Add(keyDown);
+            Controls.Add(keyRight);
+            Controls.Add(keyNumLock);
+            Controls.Add(keyPadSlash);
+            Controls.Add(keyPadAsterisk);
+            Controls.Add(keyPadMinus);
+            Controls.Add(keyPadPlus);
+            Controls.Add(keyPadEnter);
+            Controls.Add(keyPadDot);
+            Controls.Add(keyPad0);
+            Controls.Add(keyPad1);
+            Controls.Add(keyPad2);
+            Controls.Add(keyPad3);
+            Controls.Add(keyPad4);
+            Controls.Add(keyPad5);
+            Controls.Add(keyPad6);
+            Controls.Add(keyPad7);
+            Controls.Add(keyPad8);
+            Controls.Add(keyPad9);
+            Controls.Add(keyMute);
+            Controls.Add(keyVolumeDown);
+            Controls.Add(keyVolumeUp);
+            Controls.Add(keyPlayPause);
+            Controls.Add(keyMediaPrevious);
+            Controls.Add(keyMediaNext);
+            Controls.Add(keyMail);
+            Controls.Add(keyCalculator);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            KeyPreview = true;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "KeyTesterWindow";
+            ShowInTaskbar = false;
+            Text = "Key Tester";
+            Load += KeyTesterWindow_Load;
+            ResumeLayout(false);
         }
 
         #endregion

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace QMK_Toolbox.KeyTester
 {
@@ -159,7 +160,7 @@ namespace QMK_Toolbox.KeyTester
             return instance;
         }
 
-        private void KeyTesterWindow_Load(object sender, System.EventArgs e)
+        private void KeyTesterWindow_Load(object sender, EventArgs e)
         {
             CenterToParent();
         }

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.cs
@@ -159,6 +159,11 @@ namespace QMK_Toolbox.KeyTester
             return instance;
         }
 
+        private void KeyTesterWindow_Load(object sender, System.EventArgs e)
+        {
+            CenterToParent();
+        }
+
         protected override bool ProcessKeyMessage(ref Message m)
         {
             // The KeyDown and KeyUp events do not provide access to the virtual key and scancode

--- a/windows/QMK Toolbox/KeyTester/KeyTesterWindow.resx
+++ b/windows/QMK Toolbox/KeyTester/KeyTesterWindow.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -22,526 +22,507 @@
         /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
         /// </summary>
-        private void InitializeComponent() {
-            this.components = new System.ComponentModel.Container();
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            Properties.Settings settings1 = new Properties.Settings();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
-            this.flashButton = new System.Windows.Forms.Button();
-            this.windowStateBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.autoflashCheckbox = new System.Windows.Forms.CheckBox();
-            this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
-            this.openFileButton = new System.Windows.Forms.Button();
-            this.resetButton = new System.Windows.Forms.Button();
-            this.mcuLabel = new System.Windows.Forms.Label();
-            this.fileGroupBox = new System.Windows.Forms.GroupBox();
-            this.filepathBox = new QMK_Toolbox.BetterComboBox();
-            this.mcuBox = new QMK_Toolbox.MicrocontrollerSelector();
-            this.clearEepromButton = new System.Windows.Forms.Button();
-            this.logTextBox = new QMK_Toolbox.LogTextBox();
-            this.logContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.logContextMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
-            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
-            this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mainMenu = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.flashToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.eepromToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.eepromClearToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.eepromToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
-            this.eepromLeftToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.eepromRightToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.exitDFUToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.toolsToolStripMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
-            this.autoFlashToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.showAllDevicesToolStripMenuItem = new QMK_Toolbox.BindableToolStripMenuItem();
-            this.toolsToolStripMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
-            this.keyTesterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.hidConsoleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.installDriversToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolsToolStripMenuSep3 = new System.Windows.Forms.ToolStripSeparator();
-            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.windowStateBindingSource)).BeginInit();
-            this.fileGroupBox.SuspendLayout();
-            this.logContextMenu.SuspendLayout();
-            this.mainMenu.SuspendLayout();
-            this.SuspendLayout();
+            flashButton = new System.Windows.Forms.Button();
+            windowStateBindingSource = new System.Windows.Forms.BindingSource(components);
+            autoflashCheckbox = new System.Windows.Forms.CheckBox();
+            openFileDialog = new System.Windows.Forms.OpenFileDialog();
+            openFileButton = new System.Windows.Forms.Button();
+            resetButton = new System.Windows.Forms.Button();
+            mcuLabel = new System.Windows.Forms.Label();
+            fileGroupBox = new System.Windows.Forms.GroupBox();
+            filepathBox = new BetterComboBox();
+            mcuBox = new MicrocontrollerSelector();
+            clearEepromButton = new System.Windows.Forms.Button();
+            logTextBox = new LogTextBox();
+            logContextMenu = new System.Windows.Forms.ContextMenuStrip(components);
+            cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            logContextMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
+            selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            logContextMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
+            clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            mainMenu = new System.Windows.Forms.MenuStrip();
+            fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            fileToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            flashToolStripMenuItem = new BindableToolStripMenuItem();
+            eepromToolStripMenuItem = new BindableToolStripMenuItem();
+            eepromClearToolStripMenuItem = new BindableToolStripMenuItem();
+            eepromToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            eepromLeftToolStripMenuItem = new BindableToolStripMenuItem();
+            eepromRightToolStripMenuItem = new BindableToolStripMenuItem();
+            exitDFUToolStripMenuItem = new BindableToolStripMenuItem();
+            toolsToolStripMenuSep1 = new System.Windows.Forms.ToolStripSeparator();
+            autoFlashToolStripMenuItem = new BindableToolStripMenuItem();
+            showAllDevicesToolStripMenuItem = new BindableToolStripMenuItem();
+            toolsToolStripMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
+            keyTesterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            hidConsoleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            installDriversToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolsToolStripMenuSep3 = new System.Windows.Forms.ToolStripSeparator();
+            optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            helpToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
+            aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)windowStateBindingSource).BeginInit();
+            fileGroupBox.SuspendLayout();
+            logContextMenu.SuspendLayout();
+            mainMenu.SuspendLayout();
+            SuspendLayout();
             // 
             // flashButton
             // 
-            this.flashButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.flashButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanFlash", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.flashButton.Enabled = false;
-            this.flashButton.Location = new System.Drawing.Point(537, 86);
-            this.flashButton.Name = "flashButton";
-            this.flashButton.Size = new System.Drawing.Size(62, 23);
-            this.flashButton.TabIndex = 6;
-            this.flashButton.Text = "Flash";
-            this.flashButton.Click += new System.EventHandler(this.FlashButton_Click);
+            flashButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            flashButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanFlash", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            flashButton.Enabled = false;
+            flashButton.Location = new System.Drawing.Point(626, 99);
+            flashButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            flashButton.Name = "flashButton";
+            flashButton.Size = new System.Drawing.Size(72, 27);
+            flashButton.TabIndex = 6;
+            flashButton.Text = "Flash";
+            flashButton.Click += FlashButton_Click;
             // 
             // windowStateBindingSource
             // 
-            this.windowStateBindingSource.DataSource = typeof(QMK_Toolbox.WindowState);
+            windowStateBindingSource.DataSource = typeof(WindowState);
             // 
             // autoflashCheckbox
             // 
-            this.autoflashCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.autoflashCheckbox.AutoSize = true;
-            this.autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
-            this.autoflashCheckbox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.windowStateBindingSource, "AutoFlashEnabled", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.autoflashCheckbox.Location = new System.Drawing.Point(455, 90);
-            this.autoflashCheckbox.Name = "autoflashCheckbox";
-            this.autoflashCheckbox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.autoflashCheckbox.Size = new System.Drawing.Size(76, 17);
-            this.autoflashCheckbox.TabIndex = 5;
-            this.autoflashCheckbox.Text = "Auto-Flash";
-            this.autoflashCheckbox.UseVisualStyleBackColor = false;
+            autoflashCheckbox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            autoflashCheckbox.AutoSize = true;
+            autoflashCheckbox.BackColor = System.Drawing.Color.Transparent;
+            autoflashCheckbox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", windowStateBindingSource, "AutoFlashEnabled", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            autoflashCheckbox.Location = new System.Drawing.Point(536, 104);
+            autoflashCheckbox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            autoflashCheckbox.Name = "autoflashCheckbox";
+            autoflashCheckbox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            autoflashCheckbox.Size = new System.Drawing.Size(84, 19);
+            autoflashCheckbox.TabIndex = 5;
+            autoflashCheckbox.Text = "Auto-Flash";
+            autoflashCheckbox.UseVisualStyleBackColor = false;
             // 
             // openFileDialog
             // 
-            this.openFileDialog.Filter = "Intel Hex and Binary (*.hex;*.bin)|*.hex;*.bin|Intel Hex (*.hex)|*.hex|Binary (*." +
-    "bin)|*.bin";
+            openFileDialog.Filter = "Intel Hex and Binary (*.hex;*.bin)|*.hex;*.bin|Intel Hex (*.hex)|*.hex|Binary (*.bin)|*.bin";
             // 
             // openFileButton
             // 
-            this.openFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.openFileButton.Location = new System.Drawing.Point(571, 18);
-            this.openFileButton.Name = "openFileButton";
-            this.openFileButton.Size = new System.Drawing.Size(64, 23);
-            this.openFileButton.TabIndex = 2;
-            this.openFileButton.Text = "Open";
-            this.openFileButton.UseVisualStyleBackColor = true;
-            this.openFileButton.Click += new System.EventHandler(this.OpenFileButton_Click);
+            openFileButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            openFileButton.Location = new System.Drawing.Point(666, 21);
+            openFileButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            openFileButton.Name = "openFileButton";
+            openFileButton.Size = new System.Drawing.Size(75, 27);
+            openFileButton.TabIndex = 2;
+            openFileButton.Text = "Open";
+            openFileButton.UseVisualStyleBackColor = true;
+            openFileButton.Click += OpenFileButton_Click;
             // 
             // resetButton
             // 
-            this.resetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanReset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.resetButton.Enabled = false;
-            this.resetButton.Location = new System.Drawing.Point(721, 86);
-            this.resetButton.Name = "resetButton";
-            this.resetButton.Size = new System.Drawing.Size(67, 23);
-            this.resetButton.TabIndex = 8;
-            this.resetButton.Text = "Exit DFU";
-            this.resetButton.Click += new System.EventHandler(this.ResetButton_Click);
+            resetButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            resetButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanReset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            resetButton.Enabled = false;
+            resetButton.Location = new System.Drawing.Point(841, 99);
+            resetButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            resetButton.Name = "resetButton";
+            resetButton.Size = new System.Drawing.Size(78, 27);
+            resetButton.TabIndex = 8;
+            resetButton.Text = "Exit DFU";
+            resetButton.Click += ResetButton_Click;
             // 
             // mcuLabel
             // 
-            this.mcuLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.mcuLabel.AutoSize = true;
-            this.mcuLabel.Location = new System.Drawing.Point(638, 0);
-            this.mcuLabel.Name = "mcuLabel";
-            this.mcuLabel.Size = new System.Drawing.Size(84, 13);
-            this.mcuLabel.TabIndex = 3;
-            this.mcuLabel.Text = "MCU (AVR only)";
+            mcuLabel.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            mcuLabel.AutoSize = true;
+            mcuLabel.Location = new System.Drawing.Point(744, 0);
+            mcuLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            mcuLabel.Name = "mcuLabel";
+            mcuLabel.Size = new System.Drawing.Size(92, 15);
+            mcuLabel.TabIndex = 3;
+            mcuLabel.Text = "MCU (AVR only)";
             // 
             // fileGroupBox
             // 
-            this.fileGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.fileGroupBox.Controls.Add(this.openFileButton);
-            this.fileGroupBox.Controls.Add(this.filepathBox);
-            this.fileGroupBox.Controls.Add(this.mcuLabel);
-            this.fileGroupBox.Controls.Add(this.mcuBox);
-            this.fileGroupBox.Location = new System.Drawing.Point(12, 32);
-            this.fileGroupBox.Name = "fileGroupBox";
-            this.fileGroupBox.Size = new System.Drawing.Size(776, 48);
-            this.fileGroupBox.TabIndex = 0;
-            this.fileGroupBox.TabStop = false;
-            this.fileGroupBox.Text = "Local file";
+            fileGroupBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            fileGroupBox.Controls.Add(openFileButton);
+            fileGroupBox.Controls.Add(filepathBox);
+            fileGroupBox.Controls.Add(mcuLabel);
+            fileGroupBox.Controls.Add(mcuBox);
+            fileGroupBox.Location = new System.Drawing.Point(14, 37);
+            fileGroupBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            fileGroupBox.Name = "fileGroupBox";
+            fileGroupBox.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            fileGroupBox.Size = new System.Drawing.Size(905, 55);
+            fileGroupBox.TabIndex = 0;
+            fileGroupBox.TabStop = false;
+            fileGroupBox.Text = "Local file";
             // 
             // filepathBox
             // 
-            this.filepathBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::QMK_Toolbox.Properties.Settings.Default, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.filepathBox.FormattingEnabled = true;
-            this.filepathBox.Location = new System.Drawing.Point(6, 19);
-            this.filepathBox.Name = "filepathBox";
-            this.filepathBox.PlaceholderText = "Click Open or drag to window to select file";
-            this.filepathBox.Size = new System.Drawing.Size(558, 21);
-            this.filepathBox.TabIndex = 1;
-            this.filepathBox.Text = global::QMK_Toolbox.Properties.Settings.Default.hexFileSetting;
-            this.filepathBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilepathBox_KeyDown);
+            filepathBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            settings1.autoSetting = false;
+            settings1.driversInstalled = false;
+            settings1.firstStart = true;
+            settings1.hexFileCollection = null;
+            settings1.hexFileSetting = "";
+            settings1.keyboard = "";
+            settings1.keymap = "";
+            settings1.outputZoom = 1F;
+            settings1.SettingsKey = "";
+            settings1.showAllDevices = false;
+            settings1.targetSetting = "atmega32u4";
+            filepathBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", settings1, "hexFileSetting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            filepathBox.FormattingEnabled = true;
+            filepathBox.Location = new System.Drawing.Point(7, 22);
+            filepathBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            filepathBox.Name = "filepathBox";
+            filepathBox.PlaceholderText = "Click Open or drag to window to select file";
+            filepathBox.Size = new System.Drawing.Size(650, 23);
+            filepathBox.TabIndex = 1;
+            filepathBox.KeyDown += FilepathBox_KeyDown;
             // 
             // mcuBox
             // 
-            this.mcuBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.mcuBox.DisplayMember = "Value";
-            this.mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.mcuBox.FormattingEnabled = true;
-            this.mcuBox.Location = new System.Drawing.Point(641, 19);
-            this.mcuBox.Name = "mcuBox";
-            this.mcuBox.Size = new System.Drawing.Size(129, 21);
-            this.mcuBox.TabIndex = 4;
-            this.mcuBox.ValueMember = "Key";
+            mcuBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            mcuBox.DisplayMember = "Value";
+            mcuBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            mcuBox.FormattingEnabled = true;
+            mcuBox.Location = new System.Drawing.Point(748, 22);
+            mcuBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            mcuBox.Name = "mcuBox";
+            mcuBox.Size = new System.Drawing.Size(150, 23);
+            mcuBox.TabIndex = 4;
+            mcuBox.ValueMember = "Key";
             // 
             // clearEepromButton
             // 
-            this.clearEepromButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.clearEepromButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.clearEepromButton.Enabled = false;
-            this.clearEepromButton.Location = new System.Drawing.Point(605, 86);
-            this.clearEepromButton.Name = "clearEepromButton";
-            this.clearEepromButton.Size = new System.Drawing.Size(110, 23);
-            this.clearEepromButton.TabIndex = 7;
-            this.clearEepromButton.Text = "Clear EEPROM";
-            this.clearEepromButton.UseVisualStyleBackColor = true;
-            this.clearEepromButton.Click += new System.EventHandler(this.ClearEepromButton_Click);
+            clearEepromButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            clearEepromButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            clearEepromButton.Enabled = false;
+            clearEepromButton.Location = new System.Drawing.Point(706, 99);
+            clearEepromButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            clearEepromButton.Name = "clearEepromButton";
+            clearEepromButton.Size = new System.Drawing.Size(128, 27);
+            clearEepromButton.TabIndex = 7;
+            clearEepromButton.Text = "Clear EEPROM";
+            clearEepromButton.UseVisualStyleBackColor = true;
+            clearEepromButton.Click += ClearEepromButton_Click;
             // 
             // logTextBox
             // 
-            this.logTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.logTextBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
-            this.logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.logTextBox.ContextMenuStrip = this.logContextMenu;
-            this.logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", global::QMK_Toolbox.Properties.Settings.Default, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.logTextBox.DetectUrls = false;
-            this.logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.logTextBox.ForeColor = System.Drawing.Color.White;
-            this.logTextBox.HideSelection = false;
-            this.logTextBox.Location = new System.Drawing.Point(12, 115);
-            this.logTextBox.Name = "logTextBox";
-            this.logTextBox.ReadOnly = true;
-            this.logTextBox.Size = new System.Drawing.Size(776, 537);
-            this.logTextBox.TabIndex = 9;
-            this.logTextBox.Text = "";
-            this.logTextBox.WordWrap = false;
-            this.logTextBox.ZoomFactor = global::QMK_Toolbox.Properties.Settings.Default.outputZoom;
+            logTextBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            logTextBox.BackColor = System.Drawing.Color.FromArgb(30, 30, 30);
+            logTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            logTextBox.ContextMenuStrip = logContextMenu;
+            logTextBox.DataBindings.Add(new System.Windows.Forms.Binding("ZoomFactor", settings1, "outputZoom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            logTextBox.DetectUrls = false;
+            logTextBox.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            logTextBox.ForeColor = System.Drawing.Color.White;
+            logTextBox.HideSelection = false;
+            logTextBox.Location = new System.Drawing.Point(14, 133);
+            logTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            logTextBox.Name = "logTextBox";
+            logTextBox.ReadOnly = true;
+            logTextBox.Size = new System.Drawing.Size(905, 620);
+            logTextBox.TabIndex = 9;
+            logTextBox.Text = "";
+            logTextBox.WordWrap = false;
             // 
             // logContextMenu
             // 
-            this.logContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cutToolStripMenuItem,
-            this.copyToolStripMenuItem,
-            this.pasteToolStripMenuItem,
-            this.logContextMenuSep1,
-            this.selectAllToolStripMenuItem,
-            this.logContextMenuSep2,
-            this.clearToolStripMenuItem});
-            this.logContextMenu.Name = "contextMenuStrip2";
-            this.logContextMenu.ShowImageMargin = false;
-            this.logContextMenu.Size = new System.Drawing.Size(140, 126);
-            this.logContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.LogContextMenuStrip_Opening);
+            logContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { cutToolStripMenuItem, copyToolStripMenuItem, pasteToolStripMenuItem, logContextMenuSep1, selectAllToolStripMenuItem, logContextMenuSep2, clearToolStripMenuItem });
+            logContextMenu.Name = "contextMenuStrip2";
+            logContextMenu.ShowImageMargin = false;
+            logContextMenu.Size = new System.Drawing.Size(140, 126);
+            logContextMenu.Opening += LogContextMenuStrip_Opening;
             // 
             // cutToolStripMenuItem
             // 
-            this.cutToolStripMenuItem.Enabled = false;
-            this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
-            this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.cutToolStripMenuItem.Text = "Cut";
+            cutToolStripMenuItem.Enabled = false;
+            cutToolStripMenuItem.Name = "cutToolStripMenuItem";
+            cutToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X;
+            cutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            cutToolStripMenuItem.Text = "Cut";
             // 
             // copyToolStripMenuItem
             // 
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.copyToolStripMenuItem.Text = "&Copy";
-            this.copyToolStripMenuItem.Click += new System.EventHandler(this.CopyToolStripMenuItem_Click);
+            copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            copyToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C;
+            copyToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            copyToolStripMenuItem.Text = "&Copy";
+            copyToolStripMenuItem.Click += CopyToolStripMenuItem_Click;
             // 
             // pasteToolStripMenuItem
             // 
-            this.pasteToolStripMenuItem.Enabled = false;
-            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.pasteToolStripMenuItem.Text = "Paste";
+            pasteToolStripMenuItem.Enabled = false;
+            pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            pasteToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V;
+            pasteToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            pasteToolStripMenuItem.Text = "Paste";
             // 
             // logContextMenuSep1
             // 
-            this.logContextMenuSep1.Name = "logContextMenuSep1";
-            this.logContextMenuSep1.Size = new System.Drawing.Size(136, 6);
+            logContextMenuSep1.Name = "logContextMenuSep1";
+            logContextMenuSep1.Size = new System.Drawing.Size(136, 6);
             // 
             // selectAllToolStripMenuItem
             // 
-            this.selectAllToolStripMenuItem.Enabled = false;
-            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-            this.selectAllToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.selectAllToolStripMenuItem.Text = "Select &All";
-            this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.SelectAllToolStripMenuItem_Click);
+            selectAllToolStripMenuItem.Enabled = false;
+            selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            selectAllToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A;
+            selectAllToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            selectAllToolStripMenuItem.Text = "Select &All";
+            selectAllToolStripMenuItem.Click += SelectAllToolStripMenuItem_Click;
             // 
             // logContextMenuSep2
             // 
-            this.logContextMenuSep2.Name = "logContextMenuSep2";
-            this.logContextMenuSep2.Size = new System.Drawing.Size(136, 6);
+            logContextMenuSep2.Name = "logContextMenuSep2";
+            logContextMenuSep2.Size = new System.Drawing.Size(136, 6);
             // 
             // clearToolStripMenuItem
             // 
-            this.clearToolStripMenuItem.Enabled = false;
-            this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
-            this.clearToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.clearToolStripMenuItem.Text = "Clea&r";
-            this.clearToolStripMenuItem.Click += new System.EventHandler(this.ClearToolStripMenuItem_Click);
+            clearToolStripMenuItem.Enabled = false;
+            clearToolStripMenuItem.Name = "clearToolStripMenuItem";
+            clearToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+            clearToolStripMenuItem.Text = "Clea&r";
+            clearToolStripMenuItem.Click += ClearToolStripMenuItem_Click;
             // 
             // mainMenu
             // 
-            this.mainMenu.BackColor = System.Drawing.Color.Transparent;
-            this.mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem,
-            this.toolsToolStripMenuItem,
-            this.helpToolStripMenuItem});
-            this.mainMenu.Location = new System.Drawing.Point(0, 0);
-            this.mainMenu.Name = "mainMenu";
-            this.mainMenu.Size = new System.Drawing.Size(800, 24);
-            this.mainMenu.TabIndex = 0;
-            this.mainMenu.Text = "mainMenu";
+            mainMenu.BackColor = System.Drawing.Color.Transparent;
+            mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { fileToolStripMenuItem, toolsToolStripMenuItem, helpToolStripMenuItem });
+            mainMenu.Location = new System.Drawing.Point(0, 0);
+            mainMenu.Name = "mainMenu";
+            mainMenu.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            mainMenu.Size = new System.Drawing.Size(933, 24);
+            mainMenu.TabIndex = 0;
+            mainMenu.Text = "mainMenu";
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openToolStripMenuItem,
-            this.fileToolStripMenuSep,
-            this.exitToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "&File";
+            fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { openToolStripMenuItem, fileToolStripMenuSep, exitToolStripMenuItem });
+            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            fileToolStripMenuItem.Text = "&File";
             // 
             // openToolStripMenuItem
             // 
-            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.openToolStripMenuItem.Text = "&Open...";
-            this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenFileButton_Click);
+            openToolStripMenuItem.Name = "openToolStripMenuItem";
+            openToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O;
+            openToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            openToolStripMenuItem.Text = "&Open...";
+            openToolStripMenuItem.Click += OpenFileButton_Click;
             // 
             // fileToolStripMenuSep
             // 
-            this.fileToolStripMenuSep.Name = "fileToolStripMenuSep";
-            this.fileToolStripMenuSep.Size = new System.Drawing.Size(152, 6);
+            fileToolStripMenuSep.Name = "fileToolStripMenuSep";
+            fileToolStripMenuSep.Size = new System.Drawing.Size(152, 6);
             // 
             // exitToolStripMenuItem
             // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.exitToolStripMenuItem.Text = "E&xit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
+            exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            exitToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4;
+            exitToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            exitToolStripMenuItem.Text = "E&xit";
+            exitToolStripMenuItem.Click += ExitMenuItem_Click;
             // 
             // toolsToolStripMenuItem
             // 
-            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.flashToolStripMenuItem,
-            this.eepromToolStripMenuItem,
-            this.exitDFUToolStripMenuItem,
-            this.toolsToolStripMenuSep1,
-            this.autoFlashToolStripMenuItem,
-            this.showAllDevicesToolStripMenuItem,
-            this.toolsToolStripMenuSep2,
-            this.keyTesterToolStripMenuItem,
-            this.hidConsoleToolStripMenuItem,
-            this.installDriversToolStripMenuItem,
-            this.toolsToolStripMenuSep3,
-            this.optionsToolStripMenuItem});
-            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
-            this.toolsToolStripMenuItem.Text = "&Tools";
+            toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { flashToolStripMenuItem, eepromToolStripMenuItem, exitDFUToolStripMenuItem, toolsToolStripMenuSep1, autoFlashToolStripMenuItem, showAllDevicesToolStripMenuItem, toolsToolStripMenuSep2, keyTesterToolStripMenuItem, hidConsoleToolStripMenuItem, installDriversToolStripMenuItem, toolsToolStripMenuSep3, optionsToolStripMenuItem });
+            toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            toolsToolStripMenuItem.Text = "&Tools";
             // 
             // flashToolStripMenuItem
             // 
-            this.flashToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanFlash", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.flashToolStripMenuItem.Name = "flashToolStripMenuItem";
-            this.flashToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.F)));
-            this.flashToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.flashToolStripMenuItem.Text = "Flash";
-            this.flashToolStripMenuItem.Click += new System.EventHandler(this.FlashButton_Click);
+            flashToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanFlash", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            flashToolStripMenuItem.Name = "flashToolStripMenuItem";
+            flashToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F;
+            flashToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            flashToolStripMenuItem.Text = "Flash";
+            flashToolStripMenuItem.Click += FlashButton_Click;
             // 
             // eepromToolStripMenuItem
             // 
-            this.eepromToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.eepromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.eepromClearToolStripMenuItem,
-            this.eepromToolStripMenuSep,
-            this.eepromLeftToolStripMenuItem,
-            this.eepromRightToolStripMenuItem});
-            this.eepromToolStripMenuItem.Name = "eepromToolStripMenuItem";
-            this.eepromToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.eepromToolStripMenuItem.Text = "EEPROM";
+            eepromToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            eepromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { eepromClearToolStripMenuItem, eepromToolStripMenuSep, eepromLeftToolStripMenuItem, eepromRightToolStripMenuItem });
+            eepromToolStripMenuItem.Name = "eepromToolStripMenuItem";
+            eepromToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            eepromToolStripMenuItem.Text = "EEPROM";
             // 
             // eepromClearToolStripMenuItem
             // 
-            this.eepromClearToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.eepromClearToolStripMenuItem.Name = "eepromClearToolStripMenuItem";
-            this.eepromClearToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.E)));
-            this.eepromClearToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.eepromClearToolStripMenuItem.Text = "Clear";
-            this.eepromClearToolStripMenuItem.Click += new System.EventHandler(this.ClearEepromButton_Click);
+            eepromClearToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            eepromClearToolStripMenuItem.Name = "eepromClearToolStripMenuItem";
+            eepromClearToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.E;
+            eepromClearToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            eepromClearToolStripMenuItem.Text = "Clear";
+            eepromClearToolStripMenuItem.Click += ClearEepromButton_Click;
             // 
             // eepromToolStripMenuSep
             // 
-            this.eepromToolStripMenuSep.Name = "eepromToolStripMenuSep";
-            this.eepromToolStripMenuSep.Size = new System.Drawing.Size(244, 6);
+            eepromToolStripMenuSep.Name = "eepromToolStripMenuSep";
+            eepromToolStripMenuSep.Size = new System.Drawing.Size(244, 6);
             // 
             // eepromLeftToolStripMenuItem
             // 
-            this.eepromLeftToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.eepromLeftToolStripMenuItem.Name = "eepromLeftToolStripMenuItem";
-            this.eepromLeftToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.Left)));
-            this.eepromLeftToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.eepromLeftToolStripMenuItem.Tag = "left";
-            this.eepromLeftToolStripMenuItem.Text = "Set Left Hand";
-            this.eepromLeftToolStripMenuItem.Click += new System.EventHandler(this.SetHandednessButton_Click);
+            eepromLeftToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            eepromLeftToolStripMenuItem.Name = "eepromLeftToolStripMenuItem";
+            eepromLeftToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Left;
+            eepromLeftToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            eepromLeftToolStripMenuItem.Tag = "left";
+            eepromLeftToolStripMenuItem.Text = "Set Left Hand";
+            eepromLeftToolStripMenuItem.Click += SetHandednessButton_Click;
             // 
             // eepromRightToolStripMenuItem
             // 
-            this.eepromRightToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.eepromRightToolStripMenuItem.Name = "eepromRightToolStripMenuItem";
-            this.eepromRightToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.Right)));
-            this.eepromRightToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.eepromRightToolStripMenuItem.Tag = "right";
-            this.eepromRightToolStripMenuItem.Text = "Set Right Hand";
-            this.eepromRightToolStripMenuItem.Click += new System.EventHandler(this.SetHandednessButton_Click);
+            eepromRightToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanClearEeprom", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            eepromRightToolStripMenuItem.Name = "eepromRightToolStripMenuItem";
+            eepromRightToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Right;
+            eepromRightToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            eepromRightToolStripMenuItem.Tag = "right";
+            eepromRightToolStripMenuItem.Text = "Set Right Hand";
+            eepromRightToolStripMenuItem.Click += SetHandednessButton_Click;
             // 
             // exitDFUToolStripMenuItem
             // 
-            this.exitDFUToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.windowStateBindingSource, "CanReset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.exitDFUToolStripMenuItem.Name = "exitDFUToolStripMenuItem";
-            this.exitDFUToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.X)));
-            this.exitDFUToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.exitDFUToolStripMenuItem.Text = "Exit DFU";
-            this.exitDFUToolStripMenuItem.Click += new System.EventHandler(this.ResetButton_Click);
+            exitDFUToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", windowStateBindingSource, "CanReset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            exitDFUToolStripMenuItem.Name = "exitDFUToolStripMenuItem";
+            exitDFUToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.X;
+            exitDFUToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            exitDFUToolStripMenuItem.Text = "Exit DFU";
+            exitDFUToolStripMenuItem.Click += ResetButton_Click;
             // 
             // toolsToolStripMenuSep1
             // 
-            this.toolsToolStripMenuSep1.Name = "toolsToolStripMenuSep1";
-            this.toolsToolStripMenuSep1.Size = new System.Drawing.Size(193, 6);
+            toolsToolStripMenuSep1.Name = "toolsToolStripMenuSep1";
+            toolsToolStripMenuSep1.Size = new System.Drawing.Size(193, 6);
             // 
             // autoFlashToolStripMenuItem
             // 
-            this.autoFlashToolStripMenuItem.CheckOnClick = true;
-            this.autoFlashToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.windowStateBindingSource, "AutoFlashEnabled", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.autoFlashToolStripMenuItem.Name = "autoFlashToolStripMenuItem";
-            this.autoFlashToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.autoFlashToolStripMenuItem.Text = "Auto-Flash";
+            autoFlashToolStripMenuItem.CheckOnClick = true;
+            autoFlashToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Checked", windowStateBindingSource, "AutoFlashEnabled", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            autoFlashToolStripMenuItem.Name = "autoFlashToolStripMenuItem";
+            autoFlashToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            autoFlashToolStripMenuItem.Text = "Auto-Flash";
             // 
             // showAllDevicesToolStripMenuItem
             // 
-            this.showAllDevicesToolStripMenuItem.CheckOnClick = true;
-            this.showAllDevicesToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.windowStateBindingSource, "ShowAllDevices", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.showAllDevicesToolStripMenuItem.Name = "showAllDevicesToolStripMenuItem";
-            this.showAllDevicesToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.showAllDevicesToolStripMenuItem.Text = "Show All Devices";
+            showAllDevicesToolStripMenuItem.CheckOnClick = true;
+            showAllDevicesToolStripMenuItem.DataBindings.Add(new System.Windows.Forms.Binding("Checked", windowStateBindingSource, "ShowAllDevices", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            showAllDevicesToolStripMenuItem.Name = "showAllDevicesToolStripMenuItem";
+            showAllDevicesToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            showAllDevicesToolStripMenuItem.Text = "Show All Devices";
             // 
             // toolsToolStripMenuSep2
             // 
-            this.toolsToolStripMenuSep2.Name = "toolsToolStripMenuSep2";
-            this.toolsToolStripMenuSep2.Size = new System.Drawing.Size(193, 6);
+            toolsToolStripMenuSep2.Name = "toolsToolStripMenuSep2";
+            toolsToolStripMenuSep2.Size = new System.Drawing.Size(193, 6);
             // 
             // keyTesterToolStripMenuItem
             // 
-            this.keyTesterToolStripMenuItem.Name = "keyTesterToolStripMenuItem";
-            this.keyTesterToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.keyTesterToolStripMenuItem.Text = "Key Tester";
-            this.keyTesterToolStripMenuItem.Click += new System.EventHandler(this.KeyTesterToolStripMenuItem_Click);
+            keyTesterToolStripMenuItem.Name = "keyTesterToolStripMenuItem";
+            keyTesterToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            keyTesterToolStripMenuItem.Text = "Key Tester";
+            keyTesterToolStripMenuItem.Click += KeyTesterToolStripMenuItem_Click;
             // 
             // hidConsoleToolStripMenuItem
             // 
-            this.hidConsoleToolStripMenuItem.Name = "hidConsoleToolStripMenuItem";
-            this.hidConsoleToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.hidConsoleToolStripMenuItem.Text = "HID Console";
-            this.hidConsoleToolStripMenuItem.Click += new System.EventHandler(this.HidConsoleToolStripMenuItem_Click);
+            hidConsoleToolStripMenuItem.Name = "hidConsoleToolStripMenuItem";
+            hidConsoleToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            hidConsoleToolStripMenuItem.Text = "HID Console";
+            hidConsoleToolStripMenuItem.Click += HidConsoleToolStripMenuItem_Click;
             // 
             // installDriversToolStripMenuItem
             // 
-            this.installDriversToolStripMenuItem.Name = "installDriversToolStripMenuItem";
-            this.installDriversToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.installDriversToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.installDriversToolStripMenuItem.Text = "I&nstall Drivers...";
-            this.installDriversToolStripMenuItem.Click += new System.EventHandler(this.InstallDriversMenuItem_Click);
+            installDriversToolStripMenuItem.Name = "installDriversToolStripMenuItem";
+            installDriversToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N;
+            installDriversToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            installDriversToolStripMenuItem.Text = "I&nstall Drivers...";
+            installDriversToolStripMenuItem.Click += InstallDriversMenuItem_Click;
             // 
             // toolsToolStripMenuSep3
             // 
-            this.toolsToolStripMenuSep3.Name = "toolsToolStripMenuSep3";
-            this.toolsToolStripMenuSep3.Size = new System.Drawing.Size(193, 6);
+            toolsToolStripMenuSep3.Name = "toolsToolStripMenuSep3";
+            toolsToolStripMenuSep3.Size = new System.Drawing.Size(193, 6);
             // 
             // optionsToolStripMenuItem
             // 
-            this.optionsToolStripMenuItem.Enabled = false;
-            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.optionsToolStripMenuItem.Text = "O&ptions...";
+            optionsToolStripMenuItem.Enabled = false;
+            optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+            optionsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P;
+            optionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            optionsToolStripMenuItem.Text = "O&ptions...";
             // 
             // helpToolStripMenuItem
             // 
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.checkForUpdatesToolStripMenuItem,
-            this.helpToolStripMenuSep,
-            this.aboutToolStripMenuItem});
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.helpToolStripMenuItem.Text = "&Help";
+            helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { checkForUpdatesToolStripMenuItem, helpToolStripMenuSep, aboutToolStripMenuItem });
+            helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            helpToolStripMenuItem.Text = "&Help";
             // 
             // checkForUpdatesToolStripMenuItem
             // 
-            this.checkForUpdatesToolStripMenuItem.Enabled = false;
-            this.checkForUpdatesToolStripMenuItem.Name = "checkForUpdatesToolStripMenuItem";
-            this.checkForUpdatesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.checkForUpdatesToolStripMenuItem.Text = "Check for Updates...";
+            checkForUpdatesToolStripMenuItem.Enabled = false;
+            checkForUpdatesToolStripMenuItem.Name = "checkForUpdatesToolStripMenuItem";
+            checkForUpdatesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            checkForUpdatesToolStripMenuItem.Text = "Check for Updates...";
             // 
             // helpToolStripMenuSep
             // 
-            this.helpToolStripMenuSep.Name = "helpToolStripMenuSep";
-            this.helpToolStripMenuSep.Size = new System.Drawing.Size(177, 6);
+            helpToolStripMenuSep.Name = "helpToolStripMenuSep";
+            helpToolStripMenuSep.Size = new System.Drawing.Size(177, 6);
             // 
             // aboutToolStripMenuItem
             // 
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.aboutToolStripMenuItem.Text = "&About";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
+            aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            aboutToolStripMenuItem.Text = "&About";
+            aboutToolStripMenuItem.Click += AboutMenuItem_Click;
             // 
             // MainWindow
             // 
-            this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 664);
-            this.Controls.Add(this.mainMenu);
-            this.Controls.Add(this.clearEepromButton);
-            this.Controls.Add(this.fileGroupBox);
-            this.Controls.Add(this.flashButton);
-            this.Controls.Add(this.autoflashCheckbox);
-            this.Controls.Add(this.logTextBox);
-            this.Controls.Add(this.resetButton);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.mainMenu;
-            this.MinimumSize = new System.Drawing.Size(816, 703);
-            this.Name = "MainWindow";
-            this.Text = "QMK Toolbox";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainWindow_FormClosing);
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainWindow_FormClosed);
-            this.Load += new System.EventHandler(this.MainWindow_Load);
-            this.Shown += new System.EventHandler(this.MainWindow_Shown);
-            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.MainWindow_DragDrop);
-            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.MainWindow_DragEnter);
-            ((System.ComponentModel.ISupportInitialize)(this.windowStateBindingSource)).EndInit();
-            this.fileGroupBox.ResumeLayout(false);
-            this.fileGroupBox.PerformLayout();
-            this.logContextMenu.ResumeLayout(false);
-            this.mainMenu.ResumeLayout(false);
-            this.mainMenu.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AllowDrop = true;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(933, 766);
+            Controls.Add(mainMenu);
+            Controls.Add(clearEepromButton);
+            Controls.Add(fileGroupBox);
+            Controls.Add(flashButton);
+            Controls.Add(autoflashCheckbox);
+            Controls.Add(logTextBox);
+            Controls.Add(resetButton);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            MainMenuStrip = mainMenu;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MinimumSize = new System.Drawing.Size(949, 805);
+            Name = "MainWindow";
+            Text = "QMK Toolbox";
+            FormClosing += MainWindow_FormClosing;
+            FormClosed += MainWindow_FormClosed;
+            Load += MainWindow_Load;
+            Shown += MainWindow_Shown;
+            DragDrop += MainWindow_DragDrop;
+            DragEnter += MainWindow_DragEnter;
+            ((System.ComponentModel.ISupportInitialize)windowStateBindingSource).EndInit();
+            fileGroupBox.ResumeLayout(false);
+            fileGroupBox.PerformLayout();
+            logContextMenu.ResumeLayout(false);
+            mainMenu.ResumeLayout(false);
+            mainMenu.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -494,13 +494,13 @@ namespace QMK_Toolbox
 
         private void KeyTesterToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            KeyTesterWindow.GetInstance().Show();
+            KeyTesterWindow.GetInstance().Show(this);
             KeyTesterWindow.GetInstance().Focus();
         }
 
         private void HidConsoleToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            HidConsoleWindow.GetInstance().Show();
+            HidConsoleWindow.GetInstance().Show(this);
             HidConsoleWindow.GetInstance().Focus();
         }
         #endregion
@@ -508,9 +508,9 @@ namespace QMK_Toolbox
         #region Log Box
         private void LogContextMenuStrip_Opening(object sender, CancelEventArgs e)
         {
-            copyToolStripMenuItem.Enabled = (logTextBox.SelectedText.Length > 0);
-            selectAllToolStripMenuItem.Enabled = (logTextBox.Text.Length > 0);
-            clearToolStripMenuItem.Enabled = (logTextBox.Text.Length > 0);
+            copyToolStripMenuItem.Enabled = logTextBox.SelectedText.Length > 0;
+            selectAllToolStripMenuItem.Enabled = logTextBox.Text.Length > 0;
+            clearToolStripMenuItem.Enabled = logTextBox.Text.Length > 0;
         }
 
         private void CopyToolStripMenuItem_Click(object sender, EventArgs e)

--- a/windows/QMK Toolbox/MainWindow.resx
+++ b/windows/QMK Toolbox/MainWindow.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`FormStartPosition.CenterParent` doesn't work unless you show the window with `ShowDialog()`. Since we still want to allow interaction with the main window while they are open we have to use `Show()` instead and manually call `CenterToParent()` in the Load event handler.

And as usual Visual Studio wanted to move things around in the Designer.cs and resx files...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
