### PR TITLE
[Windows] Log error if driver is wrong

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -179,6 +179,11 @@ namespace QMK_Toolbox
             {
                 logTextBox.LogBootloader($"{device.Name} device connected ({device.Driver}): {device}");
 
+                if (device.PreferredDriver != device.Driver)
+                {
+                    logTextBox.LogError($"{device.Name} device has {device.Driver} driver assigned but should be {device.PreferredDriver}. Flashing may not succeed.");
+                }
+
                 if (windowState.AutoFlashEnabled)
                 {
                     FlashAllAsync();

--- a/windows/QMK Toolbox/Usb/Bootloader/AtmelDfuDevice.cs
+++ b/windows/QMK Toolbox/Usb/Bootloader/AtmelDfuDevice.cs
@@ -16,7 +16,7 @@ namespace QMK_Toolbox.Usb.Bootloader
                 Type = BootloaderType.AtmelDfu;
                 Name = "Atmel DFU";
             }
-            PreferredDriver = "libusb0";
+            PreferredDriver = "WinUSB";
             IsEepromFlashable = true;
             IsResettable = true;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`PreferredDriver` property was added ages ago but not used. This is just a simple error message if there is a driver mismatch; flashing attempts will not be prevented and there is no pointing the user at the driver installation option, as it is not guaranteed to fix the issue even for devices it does affect.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
