### PR TITLE
[Windows] Improve USB device hardware ID triplet collection

### DIFF
--- a/windows/QMK Toolbox/Usb/UsbDevice.cs
+++ b/windows/QMK Toolbox/Usb/UsbDevice.cs
@@ -29,10 +29,10 @@ namespace QMK_Toolbox.Usb
             ManufacturerString = (string)WmiDevice.GetPropertyValue("Manufacturer");
             ProductString = (string)WmiDevice.GetPropertyValue("Name");
 
-            var hardwareIdTriplet = GetHardwareId(WmiDevice);
-            VendorId = Convert.ToUInt16(hardwareIdTriplet.Groups[1].ToString(), 16);
-            ProductId = Convert.ToUInt16(hardwareIdTriplet.Groups[2].ToString(), 16);
-            RevisionBcd = Convert.ToUInt16(hardwareIdTriplet.Groups[3].ToString(), 16);
+            var hardwareIdTriplet = GetHardwareId(WmiDevice).Value;
+            VendorId = hardwareIdTriplet.Item1;
+            ProductId = hardwareIdTriplet.Item2;
+            RevisionBcd = hardwareIdTriplet.Item3;
 
             Driver = GetDriverName(WmiDevice);
         }
@@ -42,7 +42,7 @@ namespace QMK_Toolbox.Usb
             return $"{ManufacturerString} {ProductString} ({VendorId:X4}:{ProductId:X4}:{RevisionBcd:X4})";
         }
 
-        private static Match GetHardwareId(ManagementBaseObject d)
+        private static (ushort, ushort, ushort)? GetHardwareId(ManagementBaseObject d)
         {
             var hardwareIds = (string[])d.GetPropertyValue("HardwareID");
             if (hardwareIds != null)
@@ -52,7 +52,11 @@ namespace QMK_Toolbox.Usb
                     Match match = HardwareIdTripletRegex.Match(hardwareId);
                     if (match.Success)
                     {
-                        return match;
+                        return (
+                            Convert.ToUInt16(match.Groups[1].ToString(), 16),
+                            Convert.ToUInt16(match.Groups[2].ToString(), 16),
+                            Convert.ToUInt16(match.Groups[3].ToString(), 16)
+                        );
                     }
                 }
             }

--- a/windows/QMK Toolbox/Usb/UsbDevice.cs
+++ b/windows/QMK Toolbox/Usb/UsbDevice.cs
@@ -29,7 +29,7 @@ namespace QMK_Toolbox.Usb
             ManufacturerString = (string)WmiDevice.GetPropertyValue("Manufacturer");
             ProductString = (string)WmiDevice.GetPropertyValue("Name");
 
-            var hardwareIdTriplet = HardwareIdTripletRegex.Match(GetHardwareId(WmiDevice));
+            var hardwareIdTriplet = GetHardwareId(WmiDevice);
             VendorId = Convert.ToUInt16(hardwareIdTriplet.Groups[1].ToString(), 16);
             ProductId = Convert.ToUInt16(hardwareIdTriplet.Groups[2].ToString(), 16);
             RevisionBcd = Convert.ToUInt16(hardwareIdTriplet.Groups[3].ToString(), 16);
@@ -42,12 +42,19 @@ namespace QMK_Toolbox.Usb
             return $"{ManufacturerString} {ProductString} ({VendorId:X4}:{ProductId:X4}:{RevisionBcd:X4})";
         }
 
-        private static string GetHardwareId(ManagementBaseObject d)
+        private static Match GetHardwareId(ManagementBaseObject d)
         {
             var hardwareIds = (string[])d.GetPropertyValue("HardwareID");
-            if (hardwareIds != null && hardwareIds.Length > 0)
+            if (hardwareIds != null)
             {
-                return hardwareIds[0];
+                foreach (string hardwareId in hardwareIds)
+                {
+                    Match match = HardwareIdTripletRegex.Match(hardwareId);
+                    if (match.Success)
+                    {
+                        return match;
+                    }
+                }
             }
 
             return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The regex in UsbListener should ensure all detected USB devices contain a hardware ID that matches the VID/PID/REV triplet, but the UsbDevice class assumes it is always the first one in the list.

Thanks to @sigprof for pointing this out.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
