### PR TITLE
[Windows] Improve embedded resource extraction behaviour

### DIFF
--- a/windows/QMK Toolbox/Helpers/DriverInstaller.cs
+++ b/windows/QMK Toolbox/Helpers/DriverInstaller.cs
@@ -26,8 +26,9 @@ namespace QMK_Toolbox.Helpers
 
         private static bool InstallDrivers()
         {
-            var driversPath = Path.Combine(Application.LocalUserAppDataPath, DriversListFilename);
-            var installerPath = Path.Combine(Application.LocalUserAppDataPath, InstallerFilename);
+            string toolboxData = EmbeddedResourceHelper.GetResourceFolder();
+            string driversPath = Path.Combine(toolboxData, DriversListFilename);
+            string installerPath = Path.Combine(toolboxData, InstallerFilename);
 
             if (!File.Exists(driversPath))
             {

--- a/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
+++ b/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Windows.Forms;
 
 namespace QMK_Toolbox.Helpers
 {
@@ -28,9 +28,26 @@ namespace QMK_Toolbox.Helpers
             "libwinpthread-1.dll"
         };
 
+        public static string GetResourceFolder()
+        {
+            string programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            return Path.Combine(programData, "QMK Toolbox");
+        }
+
+        public static void InitResourceFolder()
+        {
+            string toolboxData = GetResourceFolder();
+            if (Directory.Exists(toolboxData))
+            {
+                Directory.Delete(toolboxData, true);
+                Directory.CreateDirectory(toolboxData);
+            }
+            ExtractResources(Resources);
+        }
+
         public static void ExtractResource(string file)
         {
-            var destPath = Path.Combine(Application.LocalUserAppDataPath, file);
+            string destPath = Path.Combine(GetResourceFolder(), file);
 
             if (!File.Exists(destPath))
             {

--- a/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
+++ b/windows/QMK Toolbox/Helpers/EmbeddedResourceHelper.cs
@@ -30,8 +30,8 @@ namespace QMK_Toolbox.Helpers
 
         public static string GetResourceFolder()
         {
-            string programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            return Path.Combine(programData, "QMK Toolbox");
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return Path.Combine(appData, "QMK", "Toolbox");
         }
 
         public static void InitResourceFolder()
@@ -40,8 +40,8 @@ namespace QMK_Toolbox.Helpers
             if (Directory.Exists(toolboxData))
             {
                 Directory.Delete(toolboxData, true);
-                Directory.CreateDirectory(toolboxData);
             }
+            Directory.CreateDirectory(toolboxData);
             ExtractResources(Resources);
         }
 

--- a/windows/QMK Toolbox/MainWindow.Designer.cs
+++ b/windows/QMK Toolbox/MainWindow.Designer.cs
@@ -73,6 +73,7 @@
             checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             helpToolStripMenuSep = new System.Windows.Forms.ToolStripSeparator();
             aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            clearResourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)windowStateBindingSource).BeginInit();
             fileGroupBox.SuspendLayout();
             logContextMenu.SuspendLayout();
@@ -338,7 +339,7 @@
             // 
             // toolsToolStripMenuItem
             // 
-            toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { flashToolStripMenuItem, eepromToolStripMenuItem, exitDFUToolStripMenuItem, toolsToolStripMenuSep1, autoFlashToolStripMenuItem, showAllDevicesToolStripMenuItem, toolsToolStripMenuSep2, keyTesterToolStripMenuItem, hidConsoleToolStripMenuItem, installDriversToolStripMenuItem, toolsToolStripMenuSep3, optionsToolStripMenuItem });
+            toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { flashToolStripMenuItem, eepromToolStripMenuItem, exitDFUToolStripMenuItem, toolsToolStripMenuSep1, autoFlashToolStripMenuItem, showAllDevicesToolStripMenuItem, toolsToolStripMenuSep2, keyTesterToolStripMenuItem, hidConsoleToolStripMenuItem, installDriversToolStripMenuItem, clearResourcesToolStripMenuItem, toolsToolStripMenuSep3, optionsToolStripMenuItem });
             toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             toolsToolStripMenuItem.Text = "&Tools";
@@ -490,6 +491,13 @@
             aboutToolStripMenuItem.Text = "&About";
             aboutToolStripMenuItem.Click += AboutMenuItem_Click;
             // 
+            // clearResourcesToolStripMenuItem
+            // 
+            clearResourcesToolStripMenuItem.Name = "clearResourcesToolStripMenuItem";
+            clearResourcesToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            clearResourcesToolStripMenuItem.Text = "Clear Resources";
+            clearResourcesToolStripMenuItem.Click += ClearResourcesMenuItem_Click;
+            // 
             // MainWindow
             // 
             AllowDrop = true;
@@ -572,5 +580,6 @@
         private System.Windows.Forms.ToolStripSeparator toolsToolStripMenuSep3;
         private QMK_Toolbox.BindableToolStripMenuItem showAllDevicesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem hidConsoleToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem clearResourcesToolStripMenuItem;
     }
 }

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -59,8 +59,6 @@ namespace QMK_Toolbox
 
             mcuBox.SelectedValue = Settings.Default.targetSetting;
 
-            EmbeddedResourceHelper.ExtractResources(EmbeddedResourceHelper.Resources);
-
             logTextBox.LogInfo($"QMK Toolbox {Application.ProductVersion} (https://qmk.fm/toolbox)");
             logTextBox.LogInfo("Supported bootloaders:");
             logTextBox.LogInfo(" - ARM DFU (APM32, Kiibohd, STM32, STM32duino) and RISC-V DFU (GD32V) via dfu-util (http://dfu-util.sourceforge.net/)");
@@ -105,6 +103,7 @@ namespace QMK_Toolbox
         {
             if (Settings.Default.firstStart)
             {
+                EmbeddedResourceHelper.InitResourceFolder();
                 Settings.Default.Upgrade();
             }
 
@@ -505,6 +504,11 @@ namespace QMK_Toolbox
         private void InstallDriversMenuItem_Click(object sender, EventArgs e)
         {
             DriverInstaller.DisplayPrompt();
+        }
+
+        private void ClearResourcesMenuItem_Click(object sender, EventArgs e)
+        {
+            EmbeddedResourceHelper.InitResourceFolder();
         }
 
         private void KeyTesterToolStripMenuItem_Click(object sender, EventArgs e)

--- a/windows/QMK Toolbox/Usb/Bootloader/BootloaderDevice.cs
+++ b/windows/QMK Toolbox/Usb/Bootloader/BootloaderDevice.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using QMK_Toolbox.Helpers;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Management;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace QMK_Toolbox.Usb.Bootloader
 {
@@ -61,14 +61,15 @@ namespace QMK_Toolbox.Usb.Bootloader
         protected async Task<int> RunProcessAsync(string command, string args)
         {
             PrintMessage($"{command} {args}", MessageType.Command);
+            string toolboxData = EmbeddedResourceHelper.GetResourceFolder();
 
             using var process = new Process
             {
                 StartInfo =
                 {
-                    FileName = Path.Combine(Application.LocalUserAppDataPath, command),
+                    FileName = Path.Combine(toolboxData, command),
                     Arguments = args,
-                    WorkingDirectory = Application.LocalUserAppDataPath,
+                    WorkingDirectory = toolboxData,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Flashers are now extracted to `ProgramData` instead of versioned `AppData\Local`
* Folder is nuked on first run/Toolbox upgrade
* Added Tools menu item to force nuke the folder

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 
