### PR TITLE
Recognize 2A03:0040 (Arduino Leonardo ETH) as a Caterina bootloader

### DIFF
--- a/macos/QMK Toolbox/USB/USBListener.swift
+++ b/macos/QMK Toolbox/USB/USBListener.swift
@@ -202,9 +202,16 @@ class USBListener: BootloaderDeviceDelegate {
             if productID == 0x0101 { // A-Star 32U4
                 return .caterina
             }
-        case 0x2341, 0x2A03: // Arduino SA, dog hunter AG
+        case 0x2341: // Arduino SA
             switch productID {
             case 0x0036, 0x0037: // Leonardo, Micro
+                return .caterina
+            default:
+                break
+            }
+        case 0x2A03: // dog hunter AG
+            switch productID {
+            case 0x0036, 0x0037, 0x0040: // Leonardo, Micro, ETH
                 return .caterina
             default:
                 break

--- a/windows/QMK Toolbox/Usb/UsbListener.cs
+++ b/windows/QMK Toolbox/Usb/UsbListener.cs
@@ -279,11 +279,19 @@ namespace QMK_Toolbox.Usb
                     }
                     break;
                 case 0x2341: // Arduino SA
+                    switch (productId)
+                    {
+                        case 0x0036: // Leonardo
+                        case 0x0037: // Micro
+                            return BootloaderType.Caterina;
+                    }
+                    break;
                 case 0x2A03: // dog hunter AG
                     switch (productId)
                     {
                         case 0x0036: // Leonardo
                         case 0x0037: // Micro
+                        case 0x0040: // ETH
                             return BootloaderType.Caterina;
                     }
                     break;


### PR DESCRIPTION
## Description

Apparently some people sell Pro Micro clones with a variant of the Caterina bootloader which shows up as `2A03:0040`; that VID:PID was originally used by the bootloader on the Arduino Leonardo ETH board. Add code to recognize that VID:PID combination as Caterina, so that those Pro Micro clones could be flashed.

Before the change the code treated the `0x2341` (Arduino SA) and `0x2A03` (dog hunter AG) VIDs identically; however, the `2341:0040` VID:PID pair apparently does not exist, therefore the code was changed to use separate branches for those VIDs and add only the `2A03:0040` combination.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The bootloader on some Pro Micro clones is not recognized by QMK toolbox (the `2A03:0040` ID was reported in https://discord.com/channels/440868230475677696/867530222407778344/1355252043157078026 and also in some private communications).
