### PR TITLE
Swap to .NET 10.0 as 6.0 is EOL.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,16 @@ on:
 jobs:
   build_win:
     name: Build (Windows)
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.x'
+
+    - name: Install InnoSetup
+      shell: cmd
+      run: choco upgrade innosetup -y --no-progress
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '10.x'
 
     - name: Install InnoSetup
       shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ on:
 jobs:
   build_win:
     name: Build (Windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.x'
+        dotnet-version: '8.x'
 
     - uses: actions/checkout@v4
 

--- a/windows/QMK Toolbox/BindableToolStripMenuItem.cs
+++ b/windows/QMK Toolbox/BindableToolStripMenuItem.cs
@@ -9,7 +9,7 @@ namespace QMK_Toolbox
         private ControlBindingsCollection _dataBindings;
 
         [Browsable(false)]
-        public BindingContext BindingContext
+        public new BindingContext BindingContext
         {
             get
             {
@@ -22,10 +22,12 @@ namespace QMK_Toolbox
             }
         }
 
+        public bool ShouldSerializeBindingContext() => false;
+
         [Category("Data")]
         [ParenthesizePropertyName(true)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public ControlBindingsCollection DataBindings
+        public new ControlBindingsCollection DataBindings
         {
             get
             {

--- a/windows/QMK Toolbox/KeyTester/KeyControl.cs
+++ b/windows/QMK Toolbox/KeyTester/KeyControl.cs
@@ -21,6 +21,8 @@ namespace QMK_Toolbox.KeyTester
             }
         }
 
+        public bool ShouldSerializePressed() => false;
+
         [Description("Whether the key has been tested."), Category("Appearance")]
         public bool Tested {
             get => tested;
@@ -31,11 +33,15 @@ namespace QMK_Toolbox.KeyTester
             }
         }
 
+        public bool ShouldSerializeTested() => false;
+
         [Description("The legend to be displayed on the key."), Category("Appearance"), Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
         public string Legend {
             get => lblLegend.Text;
             set => lblLegend.Text = value;
         }
+
+        public bool ShouldSerializeLegend() => false;
 
         private void SetKeyColor()
         {

--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <OutputType>WinExe</OutputType>
     <AssemblyName>qmk_toolbox</AssemblyName>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>qmk_toolbox</AssemblyName>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/windows/QMK Toolbox/QMK Toolbox.csproj
+++ b/windows/QMK Toolbox/QMK Toolbox.csproj
@@ -94,7 +94,6 @@
     <PackageReference Include="hidlibrary">
       <Version>3.3.40</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset">
       <Version>4.7.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

.NET 6 LTS is EOL, this bumps it up to .NET 10 LTS.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
