### PR TITLE
Fix ref to handed .eep files on Mac

### DIFF
--- a/macos/QMK Toolbox/MainViewController.swift
+++ b/macos/QMK Toolbox/MainViewController.swift
@@ -216,7 +216,7 @@ class MainViewController: NSViewController, USBListenerDelegate {
 
         for b in findBootloaders() {
             if b.eepromFlashable {
-                b.flashEEPROM(mcu, file: left ? "left.eep" : "right.eep")
+                b.flashEEPROM(mcu, file: left ? "reset_left.eep" : "reset_right.eep")
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
https://github.com/qmk/qmk_toolbox/pull/360 fixed references to the .eep files for flashing handedness, but the MacOS changes seem to be lost when moving to Swift. 

This PR updates the references to those files in the Mac bundle, which should fix errors as described in https://github.com/qmk/qmk_toolbox/issues/359 when running recent builds of QMK Toolbox on Macs.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Reference `reset_left.eep` and `reset_right.eep` instead of (the nonexistent) `left.eep` and `right.eep`.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_toolbox/issues/359 (again)
