### PR TITLE
fix: run flash operations on background thread to avoid UI message pump dependency

### DIFF
--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -293,19 +293,23 @@ namespace QMK_Toolbox
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(DisableUI));
+                DisableUI();
             }
 
-            foreach (BootloaderDevice b in FindBootloaders())
+            var bootloaders = FindBootloaders();
+            await Task.Run(async () =>
             {
-                logTextBox.LogBootloader("Attempting to flash, please don't remove device");
-                await b.Flash(selectedMcu, filePath);
-                logTextBox.LogBootloader("Flash complete");
-            }
+                foreach (BootloaderDevice b in bootloaders)
+                {
+                    Invoke(new Action(() => logTextBox.LogBootloader("Attempting to flash, please don't remove device")));
+                    await b.Flash(selectedMcu, filePath);
+                    Invoke(new Action(() => logTextBox.LogBootloader("Flash complete")));
+                }
+            });
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(EnableUI));
+                EnableUI();
             }
         }
 
@@ -315,20 +319,24 @@ namespace QMK_Toolbox
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(DisableUI));
+                DisableUI();
             }
 
-            foreach (BootloaderDevice b in FindBootloaders())
+            var bootloaders = FindBootloaders();
+            await Task.Run(async () =>
             {
-                if (b.IsResettable)
+                foreach (BootloaderDevice b in bootloaders)
                 {
-                    await b.Reset(selectedMcu);
+                    if (b.IsResettable)
+                    {
+                        await b.Reset(selectedMcu);
+                    }
                 }
-            }
+            });
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(EnableUI));
+                EnableUI();
             }
         }
 
@@ -338,22 +346,26 @@ namespace QMK_Toolbox
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(DisableUI));
+                DisableUI();
             }
 
-            foreach (BootloaderDevice b in FindBootloaders())
+            var bootloaders = FindBootloaders();
+            await Task.Run(async () =>
             {
-                if (b.IsEepromFlashable)
+                foreach (BootloaderDevice b in bootloaders)
                 {
-                    logTextBox.LogBootloader("Attempting to clear EEPROM, please don't remove device");
-                    await b.FlashEeprom(selectedMcu, "reset.eep");
-                    logTextBox.LogBootloader("EEPROM clear complete");
+                    if (b.IsEepromFlashable)
+                    {
+                        Invoke(new Action(() => logTextBox.LogBootloader("Attempting to clear EEPROM, please don't remove device")));
+                        await b.FlashEeprom(selectedMcu, "reset.eep");
+                        Invoke(new Action(() => logTextBox.LogBootloader("EEPROM clear complete")));
+                    }
                 }
-            }
+            });
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(EnableUI));
+                EnableUI();
             }
         }
 
@@ -364,22 +376,26 @@ namespace QMK_Toolbox
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(DisableUI));
+                DisableUI();
             }
 
-            foreach (BootloaderDevice b in FindBootloaders())
+            var bootloaders = FindBootloaders();
+            await Task.Run(async () =>
             {
-                if (b.IsEepromFlashable)
+                foreach (BootloaderDevice b in bootloaders)
                 {
-                    logTextBox.LogBootloader("Attempting to set handedness, please don't remove device");
-                    await b.FlashEeprom(selectedMcu, file);
-                    logTextBox.LogBootloader("EEPROM write complete");
+                    if (b.IsEepromFlashable)
+                    {
+                        Invoke(new Action(() => logTextBox.LogBootloader("Attempting to set handedness, please don't remove device")));
+                        await b.FlashEeprom(selectedMcu, file);
+                        Invoke(new Action(() => logTextBox.LogBootloader("EEPROM write complete")));
+                    }
                 }
-            }
+            });
 
             if (!windowState.AutoFlashEnabled)
             {
-                Invoke(new Action(EnableUI));
+                EnableUI();
             }
         }
 

--- a/windows/QMK Toolbox/MainWindow.cs
+++ b/windows/QMK Toolbox/MainWindow.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using System.Threading.Tasks;
 
 namespace QMK_Toolbox
 {


### PR DESCRIPTION
Flash/reset/EEPROM operations used async/await without ConfigureAwait(false), causing continuations between sequential process calls to be posted back to the UI thread via WindowsFormsSynchronizationContext. When the window received no input events, the message loop would not wake to process these continuations, stalling firmware updates for hours until a stray WM_MOUSEMOVE arrived.

Wrap bootloader operation loops in Task.Run() so continuations execute on threadpool threads with no dependency on the Windows message pump.

